### PR TITLE
test(suites): the cheap mechanical wins in the dark Service and Db suites

### DIFF
--- a/tests/Db/MagicRbacHandlerIntegrationTest.php
+++ b/tests/Db/MagicRbacHandlerIntegrationTest.php
@@ -800,6 +800,32 @@ class MagicRbacHandlerIntegrationTest extends TestCase {
 	// =========================================================================
 	// Fail-closed SQL match evaluation on null-resolved dynamic variables (#1953).
 	//
+	// 🔴 THESE THREE CANNOT PASS UNDER PHPUNIT, AND THAT IS THE FINDING, NOT A
+	// FLAKE. They were written on 2026-05-27 (#1959). On 2026-06-10 commit
+	// 4496c7f5 added a bypass to MagicRbacHandler::applyRbacFilters():
+	//
+	//     if ($user === null && PHP_SAPI === 'cli') { return; }
+	//
+	// so in ANY cli process an anonymous caller skips RBAC filtering entirely
+	// and every row comes back. PHPUnit is a cli process, so the branch these
+	// tests exercise is unreachable here and they have failed silently ever
+	// since, in a suite CI never ran.
+	//
+	// The rule they assert still holds where it matters. Measured over HTTP on
+	// 2026-09-12 against this exact schema shape (public match rule with
+	// `_organisation` => '$organisation' and one published row): an anonymous
+	// GET returned `total: 0`, the same read as admin returned 1. The web path
+	// fails closed; the cli path does not ask.
+	//
+	// Left failing on purpose rather than skipped: a reason-bearing skip here
+	// would read as "covered" in a suite that is about to become a gate. The
+	// fix belongs in production code, where "no session" alone should stop
+	// meaning "trusted" inside a cli process. OpenRegister already has the
+	// explicit mechanism for that in
+	// {@see \OCA\OpenRegister\Service\SystemOperationContext}, whose own
+	// docblock says the `PHP_SAPI === 'cli'` trust "covers occ and CLI cron
+	// only" and which exists to scope that trust to named code blocks.
+	//
 	// When a `match` rule's dynamic variable ($organisation/$userId/$now)
 	// resolves to null, the SQL/list path MUST emit an impossible predicate
 	// (1 = 0) for that property rather than dropping it from the AND. This makes

--- a/tests/Service/ActivityProviderIntegrationTest.php
+++ b/tests/Service/ActivityProviderIntegrationTest.php
@@ -45,6 +45,13 @@ class ActivityProviderIntegrationTest extends TestCase {
 	/** @var int[] */
 	private array $insertedActivityIds = [];
 
+	/**
+	 * The session user as it was before this test file touched it.
+	 *
+	 * @var IUser|null
+	 */
+	private ?IUser $previousUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->activityService = \OC::$server->get(ActivityService::class);
@@ -53,6 +60,16 @@ class ActivityProviderIntegrationTest extends TestCase {
 
 		// Activities require an active user — the publish path uses
 		// userSession->getUser() as the activity author.
+		//
+		// 🔴 WHOEVER IS LOGGED IN HERE STAYS LOGGED IN FOR THE REST OF THE RUN
+		// unless tearDown() puts it back. The session is process-global, this
+		// file is the first one PHPUnit loads in the Service suite, and it used
+		// to leave `admin` in place: 10 later assertions about what an
+		// ANONYMOUS caller may read then ran as an administrator and failed,
+		// while 12 ImportService tests passed only because an admin was
+		// carrying them. Remember what was there and restore it.
+		$this->previousUser = $this->userSession->getUser();
+
 		$userManager = \OC::$server->get(IUserManager::class);
 		$admin = $userManager->get('admin');
 		if ($admin instanceof IUser) {
@@ -73,6 +90,10 @@ class ActivityProviderIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+
+		// Put the session back the way it was found, whatever happened above.
+		$this->userSession->setUser($this->previousUser);
+
 		parent::tearDown();
 	}
 

--- a/tests/Service/AggregationRunnerIntegrationTest.php
+++ b/tests/Service/AggregationRunnerIntegrationTest.php
@@ -59,6 +59,19 @@ class AggregationRunnerIntegrationTest extends TestCase {
 	 */
 	private array $createdTables = [];
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->runner = \OC::$server->get(AggregationRunner::class);
@@ -76,6 +89,9 @@ class AggregationRunnerIntegrationTest extends TestCase {
 		$userSession = \OC::$server->get(\OCP\IUserSession::class);
 		$userManager = \OC::$server->get(\OCP\IUserManager::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin !== null) {
 			$userSession->setUser($admin);
 		}
@@ -125,6 +141,10 @@ class AggregationRunnerIntegrationTest extends TestCase {
 				// already cleaned
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}//end tearDown()

--- a/tests/Service/CalendarProviderIntegrationTest.php
+++ b/tests/Service/CalendarProviderIntegrationTest.php
@@ -47,6 +47,19 @@ class CalendarProviderIntegrationTest extends TestCase {
 	private array $createdObjectUuids = [];
 	private ?string $createdTable = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->provider = \OC::$server->get(RegisterCalendarProvider::class);
@@ -60,6 +73,9 @@ class CalendarProviderIntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(\OCP\IUserManager::class);
 		$userSession = \OC::$server->get(\OCP\IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin !== null) {
 			$userSession->setUser($admin);
 		}
@@ -102,6 +118,10 @@ class CalendarProviderIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}

--- a/tests/Service/DsarServiceIntegrationTest.php
+++ b/tests/Service/DsarServiceIntegrationTest.php
@@ -104,6 +104,19 @@ class DsarServiceIntegrationTest extends TestCase {
 
 	private ?string $previousDsarConfig = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->dsar = \OC::$server->get(DsarService::class);
@@ -122,6 +135,9 @@ class DsarServiceIntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin instanceof IUser) {
 			$userSession->setUser($admin);
 		}
@@ -204,6 +220,10 @@ class DsarServiceIntegrationTest extends TestCase {
 			} catch (\Throwable) {
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 

--- a/tests/Service/EmptyStringDateConversionIntegrationTest.php
+++ b/tests/Service/EmptyStringDateConversionIntegrationTest.php
@@ -62,7 +62,7 @@ class EmptyStringDateConversionIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Throwable $e) {
 				// best effort
 			}

--- a/tests/Service/FileActionsLifecycleIntegrationTest.php
+++ b/tests/Service/FileActionsLifecycleIntegrationTest.php
@@ -75,6 +75,19 @@ class FileActionsLifecycleIntegrationTest extends TestCase {
 
 	private array $createdFileIds = [];
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -88,6 +101,9 @@ class FileActionsLifecycleIntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin instanceof IUser) {
 			$userSession->setUser($admin);
 		}
@@ -129,6 +145,10 @@ class FileActionsLifecycleIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}//end tearDown()

--- a/tests/Service/GraphQLIntegrationTest.php
+++ b/tests/Service/GraphQLIntegrationTest.php
@@ -109,7 +109,7 @@ class GraphQLIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Exception $e) {
 				// Ignore cleanup errors.
 			}

--- a/tests/Service/GraphQLReferenceValidationIntegrationTest.php
+++ b/tests/Service/GraphQLReferenceValidationIntegrationTest.php
@@ -80,7 +80,7 @@ class GraphQLReferenceValidationIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Throwable $e) {
 				// best effort
 			}

--- a/tests/Service/GraphQLReferenceValidationIntegrationTest.php
+++ b/tests/Service/GraphQLReferenceValidationIntegrationTest.php
@@ -65,8 +65,28 @@ class GraphQLReferenceValidationIntegrationTest extends TestCase {
 	 */
 	private array $createdTables = [];
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
+
+		// 🔴 THIS FILE WRITES OBJECTS, SO IT NEEDS A CALLER WHO MAY WRITE.
+		// It never logged anybody in, and passed anyway: ten other Service
+		// files left `admin` in the process-global session, and these tests
+		// were riding on it. With that leak closed they ran as Anonymous, the
+		// writes were refused, and an import reported `created: []`. A test
+		// that needs an authenticated caller establishes one itself.
+		$userSession = \OC::$server->get(\OCP\IUserSession::class);
+		$this->previousSessionUser = $userSession->getUser();
+		$admin = \OC::$server->get(\OCP\IUserManager::class)->get('admin');
+		if ($admin !== null) {
+			$userSession->setUser($admin);
+		}
 		$this->resolver = \OC::$server->get(GraphQLResolver::class);
 		$this->saveHandler = \OC::$server->get(SaveObject::class);
 		$this->objectService = \OC::$server->get(ObjectService::class);
@@ -120,6 +140,10 @@ class GraphQLReferenceValidationIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}//end tearDown()

--- a/tests/Service/ImportRollbackIntegrationTest.php
+++ b/tests/Service/ImportRollbackIntegrationTest.php
@@ -62,8 +62,28 @@ class ImportRollbackIntegrationTest extends TestCase {
 	 */
 	private array $createdTables = [];
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
+
+		// 🔴 THIS FILE WRITES OBJECTS, SO IT NEEDS A CALLER WHO MAY WRITE.
+		// It never logged anybody in, and passed anyway: ten other Service
+		// files left `admin` in the process-global session, and these tests
+		// were riding on it. With that leak closed they ran as Anonymous, the
+		// writes were refused, and an import reported `created: []`. A test
+		// that needs an authenticated caller establishes one itself.
+		$userSession = \OC::$server->get(\OCP\IUserSession::class);
+		$this->previousSessionUser = $userSession->getUser();
+		$admin = \OC::$server->get(\OCP\IUserManager::class)->get('admin');
+		if ($admin !== null) {
+			$userSession->setUser($admin);
+		}
 		$this->importService = \OC::$server->get(ImportService::class);
 		$this->auditMapper = \OC::$server->get(AuditTrailMapper::class);
 		$this->saveHandler = \OC::$server->get(SaveObject::class);
@@ -118,6 +138,10 @@ class ImportRollbackIntegrationTest extends TestCase {
 
 		// Defensive: clear any lingering request-scoped tag.
 		$this->auditMapper->setRequestImportJobId(importJobId: null);
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}//end tearDown()

--- a/tests/Service/ImportServiceIntegrationTest.php
+++ b/tests/Service/ImportServiceIntegrationTest.php
@@ -104,12 +104,32 @@ class ImportServiceIntegrationTest extends TestCase {
 	private array $tempFiles = [];
 
 	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
+	/**
 	 * Set up test fixtures
 	 *
 	 * @return void
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+
+		// 🔴 THIS FILE WRITES OBJECTS, SO IT NEEDS A CALLER WHO MAY WRITE.
+		// It never logged anybody in, and passed anyway: ten other Service
+		// files left `admin` in the process-global session, and these tests
+		// were riding on it. With that leak closed they ran as Anonymous, the
+		// writes were refused, and an import reported `created: []`. A test
+		// that needs an authenticated caller establishes one itself.
+		$userSession = \OC::$server->get(\OCP\IUserSession::class);
+		$this->previousSessionUser = $userSession->getUser();
+		$admin = \OC::$server->get(\OCP\IUserManager::class)->get('admin');
+		if ($admin !== null) {
+			$userSession->setUser($admin);
+		}
 		$this->service = \OC::$server->get(ImportService::class);
 		$this->objectService = \OC::$server->get(ObjectService::class);
 		$this->registerMapper = \OC::$server->get(RegisterMapper::class);
@@ -159,6 +179,10 @@ class ImportServiceIntegrationTest extends TestCase {
 				// Ignore
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}

--- a/tests/Service/MailSmartPickerIntegrationTest.php
+++ b/tests/Service/MailSmartPickerIntegrationTest.php
@@ -52,6 +52,19 @@ class MailSmartPickerIntegrationTest extends TestCase {
 	private ?ObjectEntity $testObject = null;
 	private ?string $createdTable = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->provider = \OC::$server->get(ObjectReferenceProvider::class);
@@ -64,6 +77,9 @@ class MailSmartPickerIntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin instanceof IUser) {
 			$userSession->setUser($admin);
 		}
@@ -101,6 +117,10 @@ class MailSmartPickerIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}

--- a/tests/Service/ObjectHandlersIntegrationTest.php
+++ b/tests/Service/ObjectHandlersIntegrationTest.php
@@ -89,7 +89,7 @@ class ObjectHandlersIntegrationTest extends TestCase {
 		// Clean up objects first (they reference schemas/registers).
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Exception $e) {
 				// Ignore cleanup errors.
 			}

--- a/tests/Service/ObjectInteractionsIntegrationTest.php
+++ b/tests/Service/ObjectInteractionsIntegrationTest.php
@@ -48,6 +48,19 @@ class ObjectInteractionsIntegrationTest extends TestCase {
 	private ?ObjectEntity $testObject = null;
 	private ?string $createdTable = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->noteService = \OC::$server->get(NoteService::class);
@@ -61,6 +74,9 @@ class ObjectInteractionsIntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin instanceof IUser) {
 			$userSession->setUser($admin);
 		}
@@ -98,6 +114,10 @@ class ObjectInteractionsIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}

--- a/tests/Service/ObjectServiceIntegrationTest.php
+++ b/tests/Service/ObjectServiceIntegrationTest.php
@@ -93,12 +93,32 @@ class ObjectServiceIntegrationTest extends TestCase {
 	private array $createdObjectUuids = [];
 
 	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
+	/**
 	 * Set up test fixtures
 	 *
 	 * @return void
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+
+		// 🔴 THIS FILE WRITES OBJECTS, SO IT NEEDS A CALLER WHO MAY WRITE.
+		// It never logged anybody in, and passed anyway: ten other Service
+		// files left `admin` in the process-global session, and these tests
+		// were riding on it. With that leak closed they ran as Anonymous, the
+		// writes were refused, and an import reported `created: []`. A test
+		// that needs an authenticated caller establishes one itself.
+		$userSession = \OC::$server->get(\OCP\IUserSession::class);
+		$this->previousSessionUser = $userSession->getUser();
+		$admin = \OC::$server->get(\OCP\IUserManager::class)->get('admin');
+		if ($admin !== null) {
+			$userSession->setUser($admin);
+		}
 		$this->service = \OC::$server->get(ObjectService::class);
 		$this->registerMapper = \OC::$server->get(RegisterMapper::class);
 		$this->schemaMapper = \OC::$server->get(SchemaMapper::class);
@@ -159,6 +179,10 @@ class ObjectServiceIntegrationTest extends TestCase {
 				// Ignore
 			}
 		}
+
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();
 	}

--- a/tests/Service/ObjectServiceIntegrationTest.php
+++ b/tests/Service/ObjectServiceIntegrationTest.php
@@ -771,7 +771,7 @@ class ObjectServiceIntegrationTest extends TestCase {
 		$this->service->setRegister($this->testRegister);
 		$this->service->setSchema($this->testSchema);
 
-		$result = $this->service->deleteObject($uuid, false, false);
+		$result = $this->service->deleteObject($uuid, _rbac: false, _multitenancy: false);
 
 		$this->assertTrue($result);
 
@@ -792,7 +792,7 @@ class ObjectServiceIntegrationTest extends TestCase {
 		$uuid = $saved->getUuid();
 
 		// Don't set schema context - let delete derive it
-		$result = $this->service->deleteObject($uuid, false, false);
+		$result = $this->service->deleteObject($uuid, _rbac: false, _multitenancy: false);
 
 		$this->assertTrue($result);
 

--- a/tests/Service/ReferenceExistenceValidationIntegrationTest.php
+++ b/tests/Service/ReferenceExistenceValidationIntegrationTest.php
@@ -77,7 +77,7 @@ class ReferenceExistenceValidationIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Throwable $e) {
 				// best effort
 			}
@@ -297,7 +297,7 @@ class ReferenceExistenceValidationIntegrationTest extends TestCase {
 
 		// Delete the target out from under the reference.
 		try {
-			$this->objectService->deleteObject($target->getUuid(), false, false);
+			$this->objectService->deleteObject($target->getUuid(), _rbac: false, _multitenancy: false);
 		} catch (\Throwable $e) {
 			// best effort
 		}

--- a/tests/Service/ReferentialIntegrityServiceIntegrationTest.php
+++ b/tests/Service/ReferentialIntegrityServiceIntegrationTest.php
@@ -104,7 +104,7 @@ class ReferentialIntegrityServiceIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Exception $e) {
 				// Ignore
 			}

--- a/tests/Service/RegisterI18nIntegrationTest.php
+++ b/tests/Service/RegisterI18nIntegrationTest.php
@@ -66,6 +66,19 @@ class RegisterI18nIntegrationTest extends TestCase {
 	private ?ObjectEntity $testObject = null;
 	private ?string $createdTable = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->translationMapper = \OC::$server->get(TranslationMapper::class);
@@ -82,6 +95,9 @@ class RegisterI18nIntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin !== null) {
 			$userSession->setUser($admin);
 		}
@@ -127,6 +143,10 @@ class RegisterI18nIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
+
 		parent::tearDown();
 	}
 

--- a/tests/Service/RegisterI18nPhase2IntegrationTest.php
+++ b/tests/Service/RegisterI18nPhase2IntegrationTest.php
@@ -60,6 +60,19 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 	private ?ObjectEntity $testObject = null;
 	private ?string $createdTable = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->translationMapper = \OC::$server->get(TranslationMapper::class);
@@ -73,6 +86,9 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin !== null) {
 			$userSession->setUser($admin);
 		}
@@ -116,6 +132,10 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
+
 		parent::tearDown();
 	}
 

--- a/tests/Service/RegisterI18nPhase3IntegrationTest.php
+++ b/tests/Service/RegisterI18nPhase3IntegrationTest.php
@@ -56,6 +56,19 @@ class RegisterI18nPhase3IntegrationTest extends TestCase {
 	private ?ObjectEntity $testObject = null;
 	private ?string $createdTable = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->exportService = \OC::$server->get(ExportService::class);
@@ -70,6 +83,9 @@ class RegisterI18nPhase3IntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin instanceof IUser) {
 			$userSession->setUser($admin);
 		}
@@ -113,6 +129,10 @@ class RegisterI18nPhase3IntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
+
 		parent::tearDown();
 	}
 

--- a/tests/Service/RenderObjectIntegrationTest.php
+++ b/tests/Service/RenderObjectIntegrationTest.php
@@ -67,7 +67,7 @@ class RenderObjectIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Exception $e) {
 				// Ignore cleanup errors.
 			}

--- a/tests/Service/RowFieldLevelSecurityIntegrationTest.php
+++ b/tests/Service/RowFieldLevelSecurityIntegrationTest.php
@@ -37,6 +37,19 @@ class RowFieldLevelSecurityIntegrationTest extends TestCase {
 	private ?Schema $authedSchema = null;
 	private ?Schema $plainSchema = null;
 
+	/**
+	 * The session user as it was before this file touched it.
+	 *
+	 * The session is process-global and PHPUnit runs every test file in one
+	 * process, so a user left logged in here is still logged in for every file
+	 * that runs after this one. Ten Service files used to leave `admin` behind,
+	 * and assertions about what an ANONYMOUS caller may read then ran as an
+	 * administrator: some failed, and some passed only because of it.
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 		$this->propertyRbacHandler = \OC::$server->get(PropertyRbacHandler::class);
@@ -46,6 +59,9 @@ class RowFieldLevelSecurityIntegrationTest extends TestCase {
 		$userManager = \OC::$server->get(IUserManager::class);
 		$userSession = \OC::$server->get(IUserSession::class);
 		$admin = $userManager->get('admin');
+		// Restored in tearDown(): see $previousSessionUser.
+		$this->previousSessionUser = $userSession->getUser();
+
 		if ($admin instanceof IUser) {
 			$userSession->setUser($admin);
 		}
@@ -68,6 +84,10 @@ class RowFieldLevelSecurityIntegrationTest extends TestCase {
 				// best effort
 			}
 		}
+		// Put the session back the way it was found, so the next test file
+		// starts from the session state it expects.
+		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
+
 		parent::tearDown();
 	}
 

--- a/tests/Service/SaveObjectHandlersIntegrationTest.php
+++ b/tests/Service/SaveObjectHandlersIntegrationTest.php
@@ -91,7 +91,7 @@ class SaveObjectHandlersIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Exception $e) {
 				// Ignore cleanup errors.
 			}

--- a/tests/Service/SaveObjectIntegrationTest.php
+++ b/tests/Service/SaveObjectIntegrationTest.php
@@ -65,7 +65,7 @@ class SaveObjectIntegrationTest extends TestCase {
 		// Clean up objects first (they reference schemas/registers).
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Exception $e) {
 				// Ignore cleanup errors.
 			}

--- a/tests/Service/SaveObjectsIntegrationTest.php
+++ b/tests/Service/SaveObjectsIntegrationTest.php
@@ -103,7 +103,7 @@ class SaveObjectsIntegrationTest extends TestCase {
 	protected function tearDown(): void {
 		foreach ($this->createdObjectUuids as $uuid) {
 			try {
-				$this->objectService->deleteObject($uuid, false, false);
+				$this->objectService->deleteObject($uuid, _rbac: false, _multitenancy: false);
 			} catch (\Exception $e) {
 				// Ignore cleanup errors
 			}

--- a/tests/Service/UserServiceIntegrationTest.php
+++ b/tests/Service/UserServiceIntegrationTest.php
@@ -543,9 +543,18 @@ class UserServiceIntegrationTest extends TestCase {
 			$this->assertIsArray($result);
 			$this->assertArrayHasKey('organisation_updated', $result);
 		} catch (\Exception $e) {
-			// Organisation switch requires a logged-in user session, which
-			// is not available in PHPUnit context. This is expected.
-			$this->assertStringContainsString('user', strtolower($e->getMessage()));
+			// TWO REFUSALS ARE LEGITIMATE HERE, AND WHICH ONE ARRIVES DEPENDS
+			// ON WHAT RAN BEFORE. With no logged-in user the switch is refused
+			// for the session ("no user"); with one, the uuid is refused
+			// because no such organisation exists. This file run on its own
+			// used to see the first and the assertion named only that, so the
+			// test failed inside the suite for a reason that is not a defect.
+			// Both messages mean the same thing: the switch did not happen.
+			$this->assertMatchesRegularExpression(
+				'/user|organisation/i',
+				$e->getMessage(),
+				'a refused organisation switch must say whether the user or the organisation was the problem'
+			);
 		}
 	}
 

--- a/tests/Service/UserServiceIntegrationTest.php
+++ b/tests/Service/UserServiceIntegrationTest.php
@@ -76,9 +76,20 @@ class UserServiceIntegrationTest extends TestCase {
 		$this->userManager = \OC::$server->get(IUserManager::class);
 		$this->config = \OC::$server->get(IConfig::class);
 
-		// Create a test user for reliable testing
+		// Create a test user for reliable testing.
+		//
+		// 🔴 THE PASSWORD IS RANDOM PER RUN, AND IT HAS TO BE. This used to be
+		// the literal `TestPass1234!`, which is in the breach list the
+		// password_policy app checks, so `createUser()` threw
+		// "Password is present in compromised password list" in setUp and all
+		// 39 tests in this file errored before their first assertion. Any
+		// literal can end up on that list later; 32 random hex characters
+		// cannot.
 		$this->testUserId = 'phpunit-test-' . uniqid();
-		$this->testUser = $this->userManager->createUser($this->testUserId, 'TestPass1234!');
+		$this->testUser = $this->userManager->createUser(
+			$this->testUserId,
+			'Or-' . bin2hex(random_bytes(16)) . '-Aa1!'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Wave 2 of the dark-suite programme. `phpunit.xml` sets `defaultTestSuite="Unit Tests"`, so CI has never run `tests/Service` (1,440 tests), `tests/Db` (574) or `tests/Integration` (10). This PR takes the mechanical failures out of the way. It changes test code only: no file under `lib/` is touched.

## Numbers

Measured inside a real Nextcloud (conduction/nextcloud:34.0.0-apache-soap, postgres 16, openregister enabled, phpunit as www-data), never against the shared container on :8080. Both halves of the pair ran on the same instance, on this branch's merge of `origin/development` (27f85ce11), with the app upgraded first: an instance in `needsDbUpgrade` state gave two earlier runs that had to be thrown away.

The baseline is this branch with `tests/Service` and `tests/Db` checked out from `origin/development`, so the delta is this PR and nothing else.

| suite | before (pass/fail/error/skip) | after (pass/fail/error/skip) |
|---|---|---|
| Service Tests (1,440) | 836 / 26 / 576 / 2 | **1,022** / 17 / 399 / 2 |
| Database Tests (574) | 424 / 6 / 142 / 2 | 424 / 6 / 142 / 2 |
| Integration Tests (10) | 4 / 0 / 4 / 2 | 4 / 0 / 4 / 2 |

Per file, every file that moved (Service suite, pass counts):

| file | before | after |
|---|---|---|
| SaveObjectIntegrationTest | 34 | 85 |
| RenderObjectIntegrationTest | 7 | 67 |
| ObjectHandlersIntegrationTest | 48 | 72 |
| UserServiceIntegrationTest | 0 | 39 |
| ReferenceExistenceValidationIntegrationTest | 6 | 10 |
| RbacOperatorMatchingIntegrationTest | 2 | 4 |
| ObjectServiceIntegrationTest | 57 | 59 |
| StreamingBulkUpsertIntegrationTest | 1 | 3 |
| RbacScopeDiscoveryIntegrationTest | 3 | 4 |
| ReferentialIntegrityServiceIntegrationTest | 9 | 10 |

Nothing else moved, in either direction.

## 1. The tearDown signature rot: 138 tests, not the predicted 136

`ObjectService::deleteObject()` gained `$register` and `$schema` before `$_rbac`. Thirteen call sites in eleven files still passed `($uuid, false, false)`, so `false` landed in `$register` and the call raised a TypeError. Most sites are in `tearDown()`, and PHPUnit only reports a tearDown error when the test body raised nothing, so those bodies were already passing.

The prediction was "about 136 flip green with one named-argument edit". Measured on the pre-merge base, the step on its own: Service passes 830 to 968, errors 581 to 443. **138**, and the two extra are the two live calls in `ObjectServiceIntegrationTest` that were never tearDowns.

## 2. The admin session leak: eleven files, not one

`ActivityProviderIntegrationTest` calls `setUser(admin)` in setUp and never puts it back, and it is the first file the Service suite loads. Fixing only that file changed **nothing**, because ten more files do exactly the same: AggregationRunner, CalendarProvider, DsarService, FileActionsLifecycle, MailSmartPicker, ObjectInteractions, RegisterI18n, RegisterI18nPhase2, RegisterI18nPhase3, RowFieldLevelSecurity. The session is process-global, so from the earliest of them onward every assertion about what an anonymous caller may read ran as an administrator.

All eleven now remember the session user in setUp and restore it in tearDown.

**What that turned red, reported rather than hidden.** Closing the leak cost 15 passes that were only ever borrowed:

| file | passes on the leak | passes alone |
|---|---|---|
| ImportServiceIntegrationTest | 22 | 10 (12 red) |
| ImportRollbackIntegrationTest | 3 | 2 (1 red) |
| GraphQLReferenceValidationIntegrationTest | 1 | 0 (1 red) |
| ObjectServiceIntegrationTest::testCreateObject | pass | red |

Every one of them failed for the same reason, named in the error: `User 'Anonymous' does not have permission to 'create' objects`. An import that may not write reported `created: []` and called it a result. These four files write objects, so they now log in for themselves and restore the session afterwards, which is what a test needing an authenticated caller should always have done. They are green again on their own session, and the suite gained 9 real passes (RbacOperatorMatching 2, ReferenceExistence 4, StreamingBulkUpsert 2, RbacScopeDiscovery 1) that the leaked admin had been failing.

Worth a look separately, not fixed here: `ImportService` returns a success-shaped result with an empty `created` list when the caller may not write, rather than refusing.

## 3. The compromised fixture password: 39 errors

`UserServiceIntegrationTest` created its fixture user with `TestPass1234!`, which is in the breach list the `password_policy` app checks, so `createUser()` threw in setUp and all 39 tests errored before their first assertion. The password is now 32 random hex characters per run, which cannot be on any such list. 39 of 39 pass.

One test in that file then failed inside the suite while passing alone: it asserted on the wording of a refusal, and which refusal arrives depends on whether a user is logged in. Both messages mean the switch did not happen, so the assertion now accepts either and says so.

## 4. MagicRbacHandler: the three fail-closed tests are right, the bypass is wrong in its mechanism

The three tests (`testListFailsClosedOn{Multi,Single}ConditionMatchWithNullOrganisation`, `testResolvableMatchRuleStillReturnsRowsOnList`) were added on 2026-05-27 in #1959, for #1953: when a `match` rule's dynamic variable resolves to null, LIST must emit an impossible predicate rather than dropping the condition.

On 2026-06-10, commit `4496c7f5` added this to `applyRbacFilters()` (now line 331):

```php
if ($user === null && PHP_SAPI === 'cli') { return; }
```

Its own commit message says why: "MagicMapper findAll returned 0 rows in CLI/no-session context ... Added a CLI/system-context bypass ... Scoped to system/no-session only, genuine non-admin web RBAC is unchanged." The intent is sound and it fixed a real defect.

The mechanism is not. PHPUnit is a cli process with no session, so the branch these tests exercise is unreachable from any test in this suite, and they have failed silently ever since in a suite CI never ran. It is not only these three: **no test in a cli runner can cover anonymous RBAC at all** while the trust is an ambient property of the process.

Evidence that the rule still holds where it matters, measured over HTTP on 2026-09-12 against a schema carrying `read: [{group: public, match: {status: published, _organisation: "$organisation"}}]` and one published row:

```
anonymous GET /api/objects/<register>/<schema>  ->  total: 0
admin     GET /api/objects/<register>/<schema>  ->  total: 1
```

So this is a testability hole, not a live leak on the web path. The fix belongs in production code, and OpenRegister has already built the right tool for it: `SystemOperationContext`, whose own docblock says the `PHP_SAPI === 'cli'` trust "covers occ and CLI cron only" and which exists to scope that trust to named code blocks regardless of SAPI. Making the handler ask an explicit system-context signal instead of the SAPI would keep occ and cron working and give the anonymous branch back to the tests.

**No production behaviour is changed in this PR.** The three tests are left failing, not skipped: a reason-bearing skip would read as coverage in a suite that is about to become a gate. The verdict and the measurement are recorded beside them in the test file so the next reader does not have to re-litigate it. Recommend a follow-up issue for the production change.

## Mutation checks

`opcache.validate_timestamps=1` and `opcache.revalidate_freq=0` were set in the container first, and each mutation was proved live by grepping the file inside the container before the run.

| mutation | result |
|---|---|
| `SaveObjectIntegrationTest` back to positional `deleteObject($uuid, false, false)` | OK (85) becomes 51 errors |
| session restore removed from `ActivityProviderIntegrationTest`, running it with RbacOperatorMatching + ReferenceExistence | OK (19) becomes 6 failures, reproducing the original leak proof exactly |
| fixture password back to `TestPass1234!` | OK (39) becomes 39 errors |

Each was reverted afterwards and the file compared against its backup.

## What is still red, for the waves after this one

Service: BulkAndHandlers (109), Controllers (101), SaveObjectHandlers (96), ObjectsController (59), AggregationRunner (15), RelationHandlerCircuitBreaker (7) all error at construction, which is the remaining rot. Db is untouched by this PR: Mappers (103), SchemaMapper (28), RegisterMapper (7), AuditTrailMapper (4), plus the three MagicRbacHandler tests above.

## Gates

| gate | exit |
|---|---|
| `phpunit --no-coverage tests/Unit/` | 0 (19,954 tests, 24 skipped) |
| `composer phpcs` | 0 |
| Service suite in a real Nextcloud | 2, and that is the point: 399 errors of inherited rot remain |
| Database suite | 2, unchanged by this PR |

`phpcs`, `phpmd`, `phpstan` and `psalm` all scan `lib/` only, and this PR changes no file under `lib/`. phpstan and the hydra runner were still running when this was opened; their results follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
