### PR TITLE
feat(registry): implement registry-subscriptions (B22, chosen design)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,7 +40,7 @@ Open Register drijft apps zoals OpenCatalogi, Procest, Pipelinq en Software Cata
 
 Vrij en open source onder de EUPL-licentie.
     ]]></description>
-    <version>2.1.8-unstable.20260911134614</version>
+    <version>2.1.9-unstable.20260911180000</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>OpenRegister</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -840,6 +840,11 @@ return [
         // Locks.
         ['name' => 'objects#lock', 'url' => '/api/objects/{register}/{schema}/{id}/lock', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
         ['name' => 'objects#unlock', 'url' => '/api/objects/{register}/{schema}/{id}/unlock', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
+        // Registry subscriptions (registry-subscriptions, finding B22).
+        ['name' => 'registrySubscription#subscribe', 'url' => '/api/objects/{register}/{schema}/{id}/registry-subscription', 'verb' => 'POST', 'requirements' => ['id' => '[^/]+']],
+        ['name' => 'registrySubscription#unsubscribe', 'url' => '/api/objects/{register}/{schema}/{id}/registry-subscription', 'verb' => 'DELETE', 'requirements' => ['id' => '[^/]+']],
+        // The connector's inbound update, one route per registry id.
+        ['name' => 'registryUpdates#update', 'url' => '/api/registry/{registry}/updates', 'verb' => 'POST'],
         // Bulk Operations.
         ['name' => 'bulk#save', 'url' => '/api/bulk/{register}/{schema}/save', 'verb' => 'POST'],
         ['name' => 'bulk#delete', 'url' => '/api/bulk/{register}/{schema}/delete', 'verb' => 'POST'],

--- a/lib/Controller/RegistrySubscriptionController.php
+++ b/lib/Controller/RegistrySubscriptionController.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * OpenRegister RegistrySubscriptionController
+ *
+ * Lets a user with `update` on an object request or end a registry
+ * subscription (`registry-subscriptions`, finding B22). Its own controller,
+ * deliberately: `ObjectsController` already carries a large surface, and
+ * this endpoint's only dependency beyond the ordinary object lookup is
+ * {@see RegistrySubscriptionService}.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\Controller\Trait\HandlesExceptionsTrait;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\NotAuthorizedException;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\Registry\RegistrySubscriptionService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Request / end a registry subscription on one object.
+ */
+class RegistrySubscriptionController extends Controller {
+
+	use HandlesExceptionsTrait;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $appName The app id.
+	 * @param IRequest $request The request.
+	 * @param ObjectService $objectService Resolves the target object.
+	 * @param SchemaMapper $schemaMapper Resolves the object's schema.
+	 * @param PermissionHandler $permissionHandler The per-object `update` guard.
+	 * @param IUserSession $userSession The session user.
+	 * @param RegistrySubscriptionService $registrySubscriptionService Owns the subscription lifecycle.
+	 */
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly ObjectService $objectService,
+		private readonly SchemaMapper $schemaMapper,
+		private readonly PermissionHandler $permissionHandler,
+		private readonly IUserSession $userSession,
+		private readonly RegistrySubscriptionService $registrySubscriptionService,
+	) {
+		parent::__construct(appName: $appName, request: $request);
+	}//end __construct()
+
+	/**
+	 * Request a subscription on an object.
+	 *
+	 * @param string $register The register slug or identifier.
+	 * @param string $schema The schema slug or identifier.
+	 * @param string $id The object id or uuid.
+	 *
+	 * @return JSONResponse The persisted subscription state, or an error.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+	 */
+	#[NoAdminRequired]
+	public function subscribe(string $register, string $schema, string $id): JSONResponse {
+		try {
+			$object = $this->objectService->find(id: $id, register: $register, schema: $schema, _render: false);
+			$resolvedSchema = $this->schemaMapper->find(id: (string)$object->getSchema());
+
+			// IDOR guard: `update` on THIS object, not merely "authenticated".
+			$user = $this->userSession->getUser();
+			$userId = $user?->getUID();
+			$allowed = $this->permissionHandler->hasPermission(
+				schema: $resolvedSchema,
+				action: 'update',
+				userId: $userId,
+				objectOwner: $object->getOwner(),
+				object: $object,
+			);
+			if ($allowed === false) {
+				throw new NotAuthorizedException(message: 'You do not have permission to update this object.');
+			}
+
+			$row = $this->registrySubscriptionService->requestSubscription(object: $object, schema: $resolvedSchema);
+
+			return new JSONResponse(data: $row->toSelfMirror());
+		} catch (\Throwable $e) {
+			return $this->handleApiException(e: $e, context: 'registry-subscription-request');
+		}
+	}//end subscribe()
+
+	/**
+	 * End a subscription on an object.
+	 *
+	 * @param string $register The register slug or identifier.
+	 * @param string $schema The schema slug or identifier.
+	 * @param string $id The object id or uuid.
+	 *
+	 * @return JSONResponse The persisted subscription state, or an error.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+	 */
+	#[NoAdminRequired]
+	public function unsubscribe(string $register, string $schema, string $id): JSONResponse {
+		try {
+			$object = $this->objectService->find(id: $id, register: $register, schema: $schema, _render: false);
+			$resolvedSchema = $this->schemaMapper->find(id: (string)$object->getSchema());
+
+			$user = $this->userSession->getUser();
+			$userId = $user?->getUID();
+			$allowed = $this->permissionHandler->hasPermission(
+				schema: $resolvedSchema,
+				action: 'update',
+				userId: $userId,
+				objectOwner: $object->getOwner(),
+				object: $object,
+			);
+			if ($allowed === false) {
+				throw new NotAuthorizedException(message: 'You do not have permission to update this object.');
+			}
+
+			$row = $this->registrySubscriptionService->endSubscription(object: $object);
+
+			return new JSONResponse(data: $row->toSelfMirror());
+		} catch (\Throwable $e) {
+			return $this->handleApiException(e: $e, context: 'registry-subscription-end');
+		}
+	}//end unsubscribe()
+}//end class

--- a/lib/Controller/RegistrySubscriptionController.php
+++ b/lib/Controller/RegistrySubscriptionController.php
@@ -29,6 +29,8 @@ declare(strict_types=1);
 namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Controller\Trait\HandlesExceptionsTrait;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\ObjectService;
@@ -39,6 +41,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
 
 /**
  * Request / end a registry subscription on one object.
@@ -56,7 +59,8 @@ class RegistrySubscriptionController extends Controller {
 	 * @param SchemaMapper $schemaMapper Resolves the object's schema.
 	 * @param PermissionHandler $permissionHandler The per-object `update` guard.
 	 * @param IUserSession $userSession The session user.
-	 * @param RegistrySubscriptionService $registrySubscriptionService Owns the subscription lifecycle.
+	 * @param RegistrySubscriptionService $subscriptions Owns the subscription lifecycle.
+	 * @param LoggerInterface|null $logger Consumed by HandlesExceptionsTrait for server-side 500 logging.
 	 */
 	public function __construct(
 		string $appName,
@@ -65,7 +69,8 @@ class RegistrySubscriptionController extends Controller {
 		private readonly SchemaMapper $schemaMapper,
 		private readonly PermissionHandler $permissionHandler,
 		private readonly IUserSession $userSession,
-		private readonly RegistrySubscriptionService $registrySubscriptionService,
+		private readonly RegistrySubscriptionService $subscriptions,
+		private readonly ?LoggerInterface $logger = null,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()
@@ -84,24 +89,14 @@ class RegistrySubscriptionController extends Controller {
 	#[NoAdminRequired]
 	public function subscribe(string $register, string $schema, string $id): JSONResponse {
 		try {
-			$object = $this->objectService->find(id: $id, register: $register, schema: $schema, _render: false);
-			$resolvedSchema = $this->schemaMapper->find(id: (string)$object->getSchema());
+			[$object, $resolvedSchema] = $this->resolveObjectAndGuardUpdate(register: $register, schema: $schema, id: $id);
 
-			// IDOR guard: `update` on THIS object, not merely "authenticated".
-			$user = $this->userSession->getUser();
-			$userId = $user?->getUID();
-			$allowed = $this->permissionHandler->hasPermission(
-				schema: $resolvedSchema,
-				action: 'update',
-				userId: $userId,
-				objectOwner: $object->getOwner(),
-				object: $object,
+			$row = $this->subscriptions->requestSubscription(object: $object, schema: $resolvedSchema);
+
+			$this->logger?->info(
+				'[OpenRegister.RegistrySubscriptionController] Subscription requested for object '
+				. (string)$object->getUuid() . ' on registry ' . (string)$row->getRegistry()
 			);
-			if ($allowed === false) {
-				throw new NotAuthorizedException(message: 'You do not have permission to update this object.');
-			}
-
-			$row = $this->registrySubscriptionService->requestSubscription(object: $object, schema: $resolvedSchema);
 
 			return new JSONResponse(data: $row->toSelfMirror());
 		} catch (\Throwable $e) {
@@ -123,27 +118,52 @@ class RegistrySubscriptionController extends Controller {
 	#[NoAdminRequired]
 	public function unsubscribe(string $register, string $schema, string $id): JSONResponse {
 		try {
-			$object = $this->objectService->find(id: $id, register: $register, schema: $schema, _render: false);
-			$resolvedSchema = $this->schemaMapper->find(id: (string)$object->getSchema());
+			[$object] = $this->resolveObjectAndGuardUpdate(register: $register, schema: $schema, id: $id);
 
-			$user = $this->userSession->getUser();
-			$userId = $user?->getUID();
-			$allowed = $this->permissionHandler->hasPermission(
-				schema: $resolvedSchema,
-				action: 'update',
-				userId: $userId,
-				objectOwner: $object->getOwner(),
-				object: $object,
+			$row = $this->subscriptions->endSubscription(object: $object);
+
+			$this->logger?->info(
+				'[OpenRegister.RegistrySubscriptionController] Subscription ended for object '
+				. (string)$object->getUuid() . ' on registry ' . (string)$row->getRegistry()
 			);
-			if ($allowed === false) {
-				throw new NotAuthorizedException(message: 'You do not have permission to update this object.');
-			}
-
-			$row = $this->registrySubscriptionService->endSubscription(object: $object);
 
 			return new JSONResponse(data: $row->toSelfMirror());
 		} catch (\Throwable $e) {
 			return $this->handleApiException(e: $e, context: 'registry-subscription-end');
 		}
 	}//end unsubscribe()
+
+	/**
+	 * Resolve the target object and its schema, then refuse (throw) unless
+	 * the calling user has `update` on THIS specific object — the per-object
+	 * IDOR guard both endpoints in this controller need.
+	 *
+	 * @param string $register The register slug or identifier.
+	 * @param string $schema The schema slug or identifier.
+	 * @param string $id The object id or uuid.
+	 *
+	 * @return array{0: ObjectEntity, 1: Schema} The resolved object and schema.
+	 *
+	 * @throws NotAuthorizedException When the caller lacks `update` on the object.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+	 */
+	private function resolveObjectAndGuardUpdate(string $register, string $schema, string $id): array {
+		$object = $this->objectService->find(id: $id, register: $register, schema: $schema, _render: false);
+		$resolvedSchema = $this->schemaMapper->find(id: (string)$object->getSchema());
+
+		$user = $this->userSession->getUser();
+		$allowed = $this->permissionHandler->hasPermission(
+			schema: $resolvedSchema,
+			action: 'update',
+			userId: $user?->getUID(),
+			objectOwner: $object->getOwner(),
+			object: $object,
+		);
+		if ($allowed === false) {
+			throw new NotAuthorizedException(message: 'You do not have permission to update this object.');
+		}
+
+		return [$object, $resolvedSchema];
+	}//end resolveObjectAndGuardUpdate()
 }//end class

--- a/lib/Controller/RegistryUpdatesController.php
+++ b/lib/Controller/RegistryUpdatesController.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * OpenRegister RegistryUpdatesController
+ *
+ * The inbound half of `registry-subscriptions` (finding B22): a connector
+ * app (integriq) posts a registry's own change here after
+ * `RegistrySubscriptionRequestedEvent` turned into a live subscription.
+ * Authentication is the connector's Nextcloud app-password account
+ * (`registry-subscriptions` design D-3) — this is a plain `#[NoAdminRequired]`
+ * endpoint, not `#[PublicPage]`; NC core rejects an unauthenticated request
+ * before this method runs.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Controller
+ * @package  OCA\OpenRegister\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Controller;
+
+use OCA\OpenRegister\Controller\Trait\HandlesExceptionsTrait;
+use OCA\OpenRegister\Exception\ValidationException;
+use OCA\OpenRegister\Service\Registry\RegistrySubscriptionService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Applies an inbound registry update to every object subscribed to it.
+ */
+class RegistryUpdatesController extends Controller {
+
+	use HandlesExceptionsTrait;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $appName The app id.
+	 * @param IRequest $request The request.
+	 * @param RegistrySubscriptionService $registrySubscriptionService Applies the update.
+	 */
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly RegistrySubscriptionService $registrySubscriptionService,
+	) {
+		parent::__construct(appName: $appName, request: $request);
+	}//end __construct()
+
+	/**
+	 * Apply an inbound update for one registry.
+	 *
+	 * Body: `{identity: string, properties: object, eventReference: string}`.
+	 * `identity` is the BSN/KvK-number/... value the registry pushed a
+	 * change for, matched against every object's stored `identityValue` for
+	 * this `$registry` — not the property NAME, which is per-schema and
+	 * irrelevant here.
+	 *
+	 * @param string $registry The registry id (`brp`, `kvk`, ...) from the route.
+	 *
+	 * @return JSONResponse Which objects were updated, and why any were refused.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
+	 */
+	#[NoAdminRequired]
+	public function update(string $registry): JSONResponse {
+		try {
+			$data = $this->request->getParams();
+			$identity = (string)($data['identity'] ?? '');
+			$properties = $data['properties'] ?? [];
+			$eventReference = (string)($data['eventReference'] ?? '');
+
+			if ($identity === '') {
+				throw new \InvalidArgumentException('identity is required.');
+			}
+			if (is_array($properties) === false) {
+				throw new \InvalidArgumentException('properties must be an object.');
+			}
+
+			$result = $this->registrySubscriptionService->applyInboundUpdate(
+				registry: $registry,
+				identityValue: $identity,
+				properties: $properties,
+				eventReference: $eventReference,
+			);
+
+			if (count($result['applied']) === 0 && count($result['rejected']) > 0) {
+				$rejectedProperties = [];
+				foreach ($result['rejected'] as $rejection) {
+					$rejectedProperties = array_merge($rejectedProperties, $rejection['properties']);
+				}
+
+				throw new ValidationException(
+					message: 'Property not owned by the registry: ' . implode(', ', array_unique($rejectedProperties))
+				);
+			}
+
+			if ($result['matched'] === 0) {
+				return new JSONResponse(
+					data: ['message' => 'No object is subscribed to this registry/identity.'],
+					statusCode: Http::STATUS_NOT_FOUND
+				);
+			}
+
+			return new JSONResponse(data: $result);
+		} catch (\Throwable $e) {
+			return $this->handleApiException(e: $e, context: 'registry-inbound-update');
+		}
+	}//end update()
+}//end class

--- a/lib/Controller/RegistryUpdatesController.php
+++ b/lib/Controller/RegistryUpdatesController.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 
 namespace OCA\OpenRegister\Controller;
 
+use InvalidArgumentException;
 use OCA\OpenRegister\Controller\Trait\HandlesExceptionsTrait;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Service\Registry\RegistrySubscriptionService;
@@ -38,6 +39,8 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Applies an inbound registry update to every object subscribed to it.
@@ -51,12 +54,14 @@ class RegistryUpdatesController extends Controller {
 	 *
 	 * @param string $appName The app id.
 	 * @param IRequest $request The request.
-	 * @param RegistrySubscriptionService $registrySubscriptionService Applies the update.
+	 * @param RegistrySubscriptionService $subscriptions Applies the update.
+	 * @param LoggerInterface|null $logger Consumed by HandlesExceptionsTrait for server-side 500 logging.
 	 */
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		private readonly RegistrySubscriptionService $registrySubscriptionService,
+		private readonly RegistrySubscriptionService $subscriptions,
+		private readonly ?LoggerInterface $logger = null,
 	) {
 		parent::__construct(appName: $appName, request: $request);
 	}//end __construct()
@@ -85,13 +90,13 @@ class RegistryUpdatesController extends Controller {
 			$eventReference = (string)($data['eventReference'] ?? '');
 
 			if ($identity === '') {
-				throw new \InvalidArgumentException('identity is required.');
+				throw new InvalidArgumentException(message: 'identity is required.');
 			}
 			if (is_array($properties) === false) {
-				throw new \InvalidArgumentException('properties must be an object.');
+				throw new InvalidArgumentException(message: 'properties must be an object.');
 			}
 
-			$result = $this->registrySubscriptionService->applyInboundUpdate(
+			$result = $this->subscriptions->applyInboundUpdate(
 				registry: $registry,
 				identityValue: $identity,
 				properties: $properties,
@@ -110,14 +115,23 @@ class RegistryUpdatesController extends Controller {
 			}
 
 			if ($result['matched'] === 0) {
+				$this->logger?->warning(
+					'[OpenRegister.RegistryUpdatesController] No subscription found for registry ' . $registry
+				);
+
 				return new JSONResponse(
 					data: ['message' => 'No object is subscribed to this registry/identity.'],
 					statusCode: Http::STATUS_NOT_FOUND
 				);
 			}
 
+			$this->logger?->info(
+				'[OpenRegister.RegistryUpdatesController] Applied inbound update for registry ' . $registry
+				. ' to ' . count($result['applied']) . ' object(s).'
+			);
+
 			return new JSONResponse(data: $result);
-		} catch (\Throwable $e) {
+		} catch (Throwable $e) {
 			return $this->handleApiException(e: $e, context: 'registry-inbound-update');
 		}
 	}//end update()

--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -2095,11 +2095,22 @@ class AuditTrailMapper extends QBMapper {
 	}//end getStatisticsGroupedBySchema()
 
 	/**
-	 * Create a custom audit trail entry for archival operations.
+	 * Create a custom audit trail entry for archival operations, or for any
+	 * other caller that needs a non-CRUD action recorded with an explicit
+	 * actor.
+	 *
+	 * `$actorId`/`$actorName` exist for callers acting on behalf of a
+	 * non-human principal — e.g. `registry-subscriptions`' inbound update
+	 * endpoint, which authenticates as a connector's app-password account
+	 * but must audit the REGISTRY (`registry:brp`) as the actor, not
+	 * whichever Nextcloud account the app password happens to belong to.
+	 * Omit both to keep the previous session-derived behavior unchanged.
 	 *
 	 * @param ObjectEntity $object The object the entry relates to
 	 * @param string $action The archival action (e.g., archival.destroyed)
 	 * @param array $context Additional context data
+	 * @param string|null $actorId Explicit actor id, bypassing the session user. Null uses the session.
+	 * @param string|null $actorName Explicit actor display name, paired with $actorId.
 	 *
 	 * @return AuditTrail The created audit trail entry
 	 *
@@ -2109,11 +2120,29 @@ class AuditTrailMapper extends QBMapper {
 		ObjectEntity $object,
 		string $action,
 		array $context = [],
+		?string $actorId = null,
+		?string $actorName = null,
 	): AuditTrail {
-		$user = $this->userSession->getUser();
-		$userId = 'system';
-		if ($user !== null) {
-			$userId = $user->getUID();
+		$userId = $actorId;
+		$userName = $actorName;
+		if ($userId === null) {
+			$user = $this->userSession->getUser();
+			$userId = 'system';
+			$userName = 'System';
+			if ($user !== null) {
+				$userId = $user->getUID();
+				// SECURITY / AVG: keep `user_name` populated even though the
+				// migration (Version1Date20260423100000) relaxed NOT NULL on
+				// the column to support referential-integrity rows that have
+				// no displayable actor. Without this default, every audit row
+				// produced through this entry point would persist with a NULL
+				// `user_name` — undermining GDPR Art 30 §4 supervisor review.
+				$userName = $user->getDisplayName();
+			}
+		}
+
+		if ($userName === null) {
+			$userName = $userId;
 		}
 
 		$auditTrail = new AuditTrail();
@@ -2125,20 +2154,7 @@ class AuditTrailMapper extends QBMapper {
 		$auditTrail->setAction($action);
 		$auditTrail->setChanged($context);
 		$auditTrail->setUser($userId);
-
-		// SECURITY / AVG: keep `user_name` populated even though the
-		// migration (Version1Date20260423100000) relaxed NOT NULL on
-		// the column to support referential-integrity rows that have
-		// no displayable actor. Without this default, every audit row
-		// produced through this entry point would persist with a NULL
-		// `user_name` — undermining GDPR Art 30 §4 supervisor review.
-		$userName = 'System';
-		if ($user !== null) {
-			$userName = $user->getDisplayName();
-		}
-
 		$auditTrail->setUserName($userName);
-
 		$auditTrail->setCreated(new DateTime());
 
 		return $this->insertHashChained(auditTrail: $auditTrail);

--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -1090,40 +1090,7 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 			'deck' => $this->getDeck(),
 		];
 
-		// Add relevance score if set (from fuzzy search).
-		// Only included when a search was performed with _fuzzy=true.
-		if ($this->relevance !== null) {
-			$objectArray['relevance'] = $this->relevance;
-		}
-
-		// Add the RFC 8141 URN identifier if computed by the renderer.
-		// The renderer populates $this->urn via UrnService::buildForObject;
-		// when absent (e.g. raw entity not run through RenderObject) the
-		// field is simply omitted from @self.
-		if ($this->urn !== null) {
-			$objectArray['urn'] = $this->urn;
-		}
-
-		// Add per-language translation completeness when computed by the
-		// renderer. Skipped (omitted from @self) when the schema has no
-		// translatable properties or the object hasn't been rendered yet.
-		if ($this->translationCompleteness !== null) {
-			$objectArray['translationCompleteness'] = $this->translationCompleteness;
-		}
-
-		// Add the effective archival retention decision when set by the render
-		// layer (add-archival-annotation-support). Exposed as `_retention` and
-		// omitted entirely when the object carries no retention metadata.
-		if ($this->archivalRetention !== null) {
-			$objectArray['_retention'] = $this->archivalRetention;
-		}
-
-		// Add the registry subscription state when set by the render layer
-		// (`registry-subscriptions`, finding B22). Exposed as `registry` and
-		// omitted entirely for an object that never requested one.
-		if ($this->registryState !== null) {
-			$objectArray['registry'] = $this->registryState;
-		}
+		$objectArray = $this->mergeTransientRenderFields(objectArray: $objectArray);
 
 		// Check for '@self' in the provided object array (this is the case if the object metadata is extended).
 		if (($object['@self'] ?? null) !== null && is_array($object['@self']) === true) {
@@ -1153,6 +1120,58 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 
 		return $objectArray;
 	}//end getObjectArray()
+
+	/**
+	 * Merge the transient, render-layer-populated `@self` fields: fuzzy
+	 * search relevance, the RFC 8141 URN, per-language translation
+	 * completeness, the effective archival retention decision, and the
+	 * registry subscription state (`registry-subscriptions`, finding B22).
+	 * Each is optional and omitted entirely when unset — none of these are
+	 * persisted on this entity; they are populated by RenderObject at read
+	 * time.
+	 *
+	 * Extracted out of {@see getObjectArray()} to keep that method under
+	 * this repo's PHPMD line-count threshold.
+	 *
+	 * @param array<string, mixed> $objectArray The array built so far.
+	 *
+	 * @return array<string, mixed> The array with any set transient fields merged in.
+	 */
+	private function mergeTransientRenderFields(array $objectArray): array {
+		// Only included when a search was performed with _fuzzy=true.
+		if ($this->relevance !== null) {
+			$objectArray['relevance'] = $this->relevance;
+		}
+
+		// The renderer populates $this->urn via UrnService::buildForObject;
+		// when absent (e.g. raw entity not run through RenderObject) the
+		// field is simply omitted from @self.
+		if ($this->urn !== null) {
+			$objectArray['urn'] = $this->urn;
+		}
+
+		// Skipped (omitted from @self) when the schema has no translatable
+		// properties or the object hasn't been rendered yet.
+		if ($this->translationCompleteness !== null) {
+			$objectArray['translationCompleteness'] = $this->translationCompleteness;
+		}
+
+		// Add the effective archival retention decision when set by the render
+		// layer (add-archival-annotation-support). Exposed as `_retention` and
+		// omitted entirely when the object carries no retention metadata.
+		if ($this->archivalRetention !== null) {
+			$objectArray['_retention'] = $this->archivalRetention;
+		}
+
+		// Add the registry subscription state when set by the render layer.
+		// Exposed as `registry` and omitted entirely for an object that
+		// never requested one.
+		if ($this->registryState !== null) {
+			$objectArray['registry'] = $this->registryState;
+		}
+
+		return $objectArray;
+	}//end mergeTransientRenderFields()
 
 	/**
 	 * Format DateTime object to ISO 8601 string or return null

--- a/lib/Db/ObjectEntity.php
+++ b/lib/Db/ObjectEntity.php
@@ -555,6 +555,23 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 	protected ?array $archivalRetention = null;
 
 	/**
+	 * Registry subscription state for this object (`registry-subscriptions`,
+	 * finding B22).
+	 *
+	 * Transient property populated by the render layer from
+	 * `RegistrySubscriptionService::stateFor()`/`statesFor()` — shape:
+	 *   `['registry' => 'brp', 'state' => 'active', 'lastUpdate' => '...',
+	 *      'lastUpdateSource' => '...', 'refusalReason' => null|string]`.
+	 * Not persisted on this entity (the state lives in
+	 * `openregister_registry_subs`, keyed by object uuid). Exposed in @self
+	 * as `registry`, and omitted entirely for an object whose schema does
+	 * not declare `x-openregister-registry` or that never requested one.
+	 *
+	 * @var array<string, mixed>|null
+	 */
+	protected ?array $registryState = null;
+
+	/**
 	 * AVG / GDPR Art 30 processing-activity override.
 	 *
 	 * Transient field — set by callers that want to tag an upcoming
@@ -700,6 +717,28 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 	public function setArchivalRetention(?array $retention): void {
 		$this->archivalRetention = $retention;
 	}//end setArchivalRetention()
+
+	/**
+	 * Get the registry subscription state, when set by the render layer.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function getRegistryState(): ?array {
+		return $this->registryState;
+	}//end getRegistryState()
+
+	/**
+	 * Write the registry subscription state.
+	 *
+	 * Surfaced in the @self envelope as `registry` by getObjectArray().
+	 *
+	 * @param array<string, mixed>|null $state The subscription state mirror.
+	 *
+	 * @return void
+	 */
+	public function setRegistryState(?array $state): void {
+		$this->registryState = $state;
+	}//end setRegistryState()
 
 	/**
 	 * Initialize the entity and define field types
@@ -1077,6 +1116,13 @@ class ObjectEntity extends Entity implements JsonSerializable, ObjectEntityInter
 		// omitted entirely when the object carries no retention metadata.
 		if ($this->archivalRetention !== null) {
 			$objectArray['_retention'] = $this->archivalRetention;
+		}
+
+		// Add the registry subscription state when set by the render layer
+		// (`registry-subscriptions`, finding B22). Exposed as `registry` and
+		// omitted entirely for an object that never requested one.
+		if ($this->registryState !== null) {
+			$objectArray['registry'] = $this->registryState;
 		}
 
 		// Check for '@self' in the provided object array (this is the case if the object metadata is extended).

--- a/lib/Db/RegistrySubscription.php
+++ b/lib/Db/RegistrySubscription.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * The registry subscription state for one object (finding B22).
+ *
+ * One row per object that declared `x-openregister-registry` and requested
+ * a subscription, keyed by object uuid (design.md D-2 of
+ * `registry-subscriptions`). Holds subscription state and freshness only —
+ * never a copy of the subscribed person or company's data. The object
+ * OpenRegister already stores, in whichever app's register declared the
+ * schema, is the only copy.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use DateTime;
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * One object's registry subscription state.
+ *
+ * @method string|null getObjectUuid()
+ * @method void setObjectUuid(?string $objectUuid)
+ * @method string|null getRegister()
+ * @method void setRegister(?string $register)
+ * @method string|null getSchema()
+ * @method void setSchema(?string $schema)
+ * @method string|null getRegistry()
+ * @method void setRegistry(?string $registry)
+ * @method string|null getIdentityValue()
+ * @method void setIdentityValue(?string $identityValue)
+ * @method string|null getState()
+ * @method void setState(?string $state)
+ * @method DateTime|null getLastUpdateAt()
+ * @method void setLastUpdateAt(?DateTime $lastUpdateAt)
+ * @method string|null getLastUpdateSource()
+ * @method void setLastUpdateSource(?string $lastUpdateSource)
+ * @method string|null getRefusalReason()
+ * @method void setRefusalReason(?string $refusalReason)
+ * @method DateTime|null getCreatedAt()
+ * @method void setCreatedAt(?DateTime $createdAt)
+ * @method DateTime|null getUpdatedAt()
+ * @method void setUpdatedAt(?DateTime $updatedAt)
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+class RegistrySubscription extends Entity implements JsonSerializable {
+
+	/**
+	 * No subscription has ever been requested.
+	 */
+	public const STATE_NONE = 'none';
+
+	/**
+	 * A user requested a subscription; the connector has not confirmed yet.
+	 */
+	public const STATE_REQUESTED = 'requested';
+
+	/**
+	 * The connector confirmed the subscription is live at the source.
+	 */
+	public const STATE_ACTIVE = 'active';
+
+	/**
+	 * A user ended the subscription.
+	 */
+	public const STATE_ENDED = 'ended';
+
+	/**
+	 * The connector reported the subscription could not be established.
+	 */
+	public const STATE_FAILED = 'failed';
+
+	/**
+	 * The uuid of the object this row tracks.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $objectUuid = null;
+
+	/**
+	 * The register the object lives in.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $register = null;
+
+	/**
+	 * The schema the object was saved against.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $schema = null;
+
+	/**
+	 * The registry id (`brp`, `kvk`, ...) from the schema's
+	 * `x-openregister-registry.registry`.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $registry = null;
+
+	/**
+	 * The object's identity value at the registry (the BSN, KvK number,
+	 * ...), read from the property named by `x-openregister-registry.identity`
+	 * at request time.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $identityValue = null;
+
+	/**
+	 * One of the STATE_* constants.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $state = self::STATE_NONE;
+
+	/**
+	 * When the object's owned properties were last updated by the registry.
+	 *
+	 * @var DateTime|null
+	 */
+	protected ?DateTime $lastUpdateAt = null;
+
+	/**
+	 * The registry's own event reference for the last update.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $lastUpdateSource = null;
+
+	/**
+	 * The connector's error text when `state` is `failed`.
+	 *
+	 * @var string|null
+	 */
+	protected ?string $refusalReason = null;
+
+	/**
+	 * When this row was first created.
+	 *
+	 * @var DateTime|null
+	 */
+	protected ?DateTime $createdAt = null;
+
+	/**
+	 * When this row last changed.
+	 *
+	 * @var DateTime|null
+	 */
+	protected ?DateTime $updatedAt = null;
+
+	/**
+	 * Constructor: declare field types so the mapper hydrates them correctly.
+	 */
+	public function __construct() {
+		$this->addType(fieldName: 'objectUuid', type: 'string');
+		$this->addType(fieldName: 'register', type: 'string');
+		$this->addType(fieldName: 'schema', type: 'string');
+		$this->addType(fieldName: 'registry', type: 'string');
+		$this->addType(fieldName: 'identityValue', type: 'string');
+		$this->addType(fieldName: 'state', type: 'string');
+		$this->addType(fieldName: 'lastUpdateAt', type: 'datetime');
+		$this->addType(fieldName: 'lastUpdateSource', type: 'string');
+		$this->addType(fieldName: 'refusalReason', type: 'string');
+		$this->addType(fieldName: 'createdAt', type: 'datetime');
+		$this->addType(fieldName: 'updatedAt', type: 'datetime');
+	}//end __construct()
+
+	/**
+	 * The `@self.registry` render mirror for this row.
+	 *
+	 * @return array<string, mixed> The shape `registry-subscriptions` REQ 2 names.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+	 */
+	public function toSelfMirror(): array {
+		return [
+			'registry' => $this->registry,
+			'state' => ($this->state ?? self::STATE_NONE),
+			'lastUpdate' => $this->lastUpdateAt?->format('c'),
+			'lastUpdateSource' => $this->lastUpdateSource,
+			'refusalReason' => $this->refusalReason,
+		];
+	}//end toSelfMirror()
+
+	/**
+	 * Serialise for diagnostics.
+	 *
+	 * @return array<string, mixed> The row as plain data.
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->id,
+			'objectUuid' => $this->objectUuid,
+			'register' => $this->register,
+			'schema' => $this->schema,
+			'registry' => $this->registry,
+			'identityValue' => $this->identityValue,
+			'state' => $this->state,
+			'lastUpdateAt' => $this->lastUpdateAt?->format('c'),
+			'lastUpdateSource' => $this->lastUpdateSource,
+			'refusalReason' => $this->refusalReason,
+			'createdAt' => $this->createdAt?->format('c'),
+			'updatedAt' => $this->updatedAt?->format('c'),
+		];
+	}//end jsonSerialize()
+}//end class

--- a/lib/Db/RegistrySubscriptionMapper.php
+++ b/lib/Db/RegistrySubscriptionMapper.php
@@ -1,0 +1,148 @@
+<?php
+
+/**
+ * Mapper for the registry subscription state (finding B22).
+ *
+ * One row per object, keyed by object uuid. Requesting a subscription
+ * again upserts the same row rather than creating a second one.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Db
+ * @package  OCA\OpenRegister\Db
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * Reads and writes `openregister_registry_subs`.
+ *
+ * @template-extends QBMapper<RegistrySubscription>
+ */
+class RegistrySubscriptionMapper extends QBMapper {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IDBConnection $db The database connection.
+	 */
+	public function __construct(IDBConnection $db) {
+		parent::__construct(db: $db, tableName: 'openregister_registry_subs', entityClass: RegistrySubscription::class);
+	}//end __construct()
+
+	/**
+	 * The subscription row for one object, or null when it never requested one.
+	 *
+	 * @param string $objectUuid The object's uuid.
+	 *
+	 * @return RegistrySubscription|null The row, when any.
+	 */
+	public function findForObject(string $objectUuid): ?RegistrySubscription {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('object_uuid', $qb->createNamedParameter($objectUuid)))
+			->setMaxResults(1);
+
+		try {
+			return $this->findEntity(query: $qb);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}//end findForObject()
+
+	/**
+	 * The subscription rows for one object per batch call, indexed by
+	 * object uuid, for the render-mirror choke point to consult without an
+	 * N+1 query per listed row.
+	 *
+	 * @param array<int, string> $objectUuids The object uuids to look up.
+	 *
+	 * @return array<string, RegistrySubscription> Rows found, keyed by object uuid.
+	 */
+	public function findForObjects(array $objectUuids): array {
+		if (count($objectUuids) === 0) {
+			return [];
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->in('object_uuid', $qb->createNamedParameter($objectUuids, IQueryBuilder::PARAM_STR_ARRAY)));
+
+		$rows = [];
+		foreach ($this->findEntities(query: $qb) as $row) {
+			$rows[(string)$row->getObjectUuid()] = $row;
+		}
+
+		return $rows;
+	}//end findForObjects()
+
+	/**
+	 * Every ACTIVE row subscribed to a given registry+identity value — the
+	 * inbound update endpoint's lookup path. More than one row can match:
+	 * two different objects (in different registers) may legitimately track
+	 * the same real-world BSN or KvK number.
+	 *
+	 * @param string $registry The registry id (`brp`, `kvk`, ...).
+	 * @param string $identityValue The identity value the registry pushed a change for.
+	 *
+	 * @return array<int, RegistrySubscription> Matching active rows.
+	 */
+	public function findActiveByIdentity(string $registry, string $identityValue): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('registry', $qb->createNamedParameter($registry)))
+			->andWhere($qb->expr()->eq('identity_value', $qb->createNamedParameter($identityValue)))
+			->andWhere($qb->expr()->eq('state', $qb->createNamedParameter(RegistrySubscription::STATE_ACTIVE)));
+
+		return $this->findEntities(query: $qb);
+	}//end findActiveByIdentity()
+
+	/**
+	 * Insert or update a state row, keyed by object uuid.
+	 *
+	 * @param RegistrySubscription $subscription The row to persist.
+	 *
+	 * @return RegistrySubscription The persisted row.
+	 */
+	public function save(RegistrySubscription $subscription): RegistrySubscription {
+		if ($subscription->getId() === null) {
+			return $this->insert(entity: $subscription);
+		}
+
+		return $this->update(entity: $subscription);
+	}//end save()
+
+	/**
+	 * Delete the subscription row for an object, if any (called when the
+	 * object itself is deleted — this table never outlives its object).
+	 *
+	 * @param string $objectUuid The object's uuid.
+	 *
+	 * @return void
+	 */
+	public function deleteForObject(string $objectUuid): void {
+		$row = $this->findForObject(objectUuid: $objectUuid);
+		if ($row !== null) {
+			$this->delete(entity: $row);
+		}
+	}//end deleteForObject()
+}//end class

--- a/lib/Db/Schema.php
+++ b/lib/Db/Schema.php
@@ -2474,6 +2474,13 @@ class Schema extends Entity implements JsonSerializable {
 		// or#460/#462-class trap as `x-openregister-processing` and
 		// `x-openregister-contextchat` above. See or#2164.
 		'x-openregister-agent-context',
+		// Registry-subscriptions: names the external registry (brp/kvk/...)
+		// that owns a subset of this schema's properties, the identity
+		// property, and the owned property list. Absent from this list,
+		// setConfiguration() would silently DROP it and a schema author
+		// could never opt an object into a subscription — same
+		// or#460/#462-class trap as every entry above.
+		'x-openregister-registry',
 	];
 
 	/**

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -37,6 +37,7 @@ use OCA\OpenRegister\Service\Handoff\HandoffAnnotationValidator;
 use OCA\OpenRegister\Service\Handoff\HandoffContractBindingValidator;
 use OCA\OpenRegister\Service\Lifecycle\LifecycleAnnotationValidator;
 use OCA\OpenRegister\Service\Mcp\McpAnnotationValidator;
+use OCA\OpenRegister\Service\Registry\RegistryAnnotationValidator;
 use OCA\OpenRegister\Service\Merge\MergeAnnotationValidator;
 use OCA\OpenRegister\Service\Notification\NotificationAnnotationValidator;
 use OCA\OpenRegister\Service\Quality\DedupAnnotationValidator;
@@ -1096,6 +1097,7 @@ class SchemaMapper extends QBMapper {
 		$this->validateHandoffAnnotation(schema: $schema);
 		$this->validateHandoffContractBinding(schema: $schema);
 		$this->validateMcpAnnotation(schema: $schema);
+		$this->validateRegistryAnnotation(schema: $schema);
 		$this->logDroppedAnnotationKeys(schema: $schema);
 	}//end cleanObject()
 
@@ -1663,6 +1665,45 @@ class SchemaMapper extends QBMapper {
 		$messages = array_map(static fn (array $err) => $err['code'] . ': ' . $err['message'], $errors);
 		throw new Exception('x-openregister-mcp: ' . implode(' ', $messages));
 	}//end validateMcpAnnotation()
+
+	/**
+	 * Validate the optional `x-openregister-registry` annotation.
+	 *
+	 * The annotation is stored under `configuration['x-openregister-registry']`.
+	 * Per `registry-subscriptions` REQ 1, an annotation naming an `identity`
+	 * or `owned` property the schema does not declare MUST refuse the save
+	 * — unlike most other `x-openregister-*` dialects, this one is
+	 * BLOCKING, not advisory, because a stored-but-wrong annotation would
+	 * let the inbound registry endpoint write a property nobody reviewed.
+	 *
+	 * @param Schema $schema Schema to validate.
+	 *
+	 * @throws Exception When the annotation is malformed.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
+	 */
+	private function validateRegistryAnnotation(Schema $schema): void {
+		$configuration = ($schema->getConfiguration() ?? []);
+		$annotation = ($configuration['x-openregister-registry'] ?? null);
+		if (is_array($annotation) === false) {
+			return;
+		}
+
+		$shape = [
+			'properties' => ($schema->getProperties() ?? []),
+			'x-openregister-registry' => $annotation,
+		];
+
+		$errors = (new RegistryAnnotationValidator())->validate($shape);
+		if (count($errors) === 0) {
+			return;
+		}
+
+		$messages = array_map(static fn (array $err) => $err['code'] . ': ' . $err['message'], $errors);
+		throw new Exception('x-openregister-registry: ' . implode(' ', $messages));
+	}//end validateRegistryAnnotation()
 
 	/**
 	 * Clean $ref properties to ensure they are strings

--- a/lib/Event/RegistrySubscriptionEndedEvent.php
+++ b/lib/Event/RegistrySubscriptionEndedEvent.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * OpenRegister RegistrySubscriptionEndedEvent
+ *
+ * Cross-app command event (finding B22): dispatched when a user with
+ * `update` on an object ends its registry subscription. A connector app
+ * (integriq) registers an IEventListener for this event and unsubscribes
+ * at the source.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Event
+ * @package  OCA\OpenRegister\Event
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Event dispatched to end a registry subscription on an object.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+class RegistrySubscriptionEndedEvent extends Event {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $objectUuid UUID of the object ending its subscription.
+	 * @param string $registry The registry id (`brp`, `kvk`, ...).
+	 * @param string $identityValue The object's identity value at that registry.
+	 */
+	public function __construct(
+		private readonly string $objectUuid,
+		private readonly string $registry,
+		private readonly string $identityValue,
+	) {
+		parent::__construct();
+	}//end __construct()
+
+	/**
+	 * Get the object's UUID.
+	 *
+	 * @return string
+	 */
+	public function getObjectUuid(): string {
+		return $this->objectUuid;
+	}//end getObjectUuid()
+
+	/**
+	 * Get the registry id (`brp`, `kvk`, ...).
+	 *
+	 * @return string
+	 */
+	public function getRegistry(): string {
+		return $this->registry;
+	}//end getRegistry()
+
+	/**
+	 * Get the object's identity value at the registry.
+	 *
+	 * @return string
+	 */
+	public function getIdentityValue(): string {
+		return $this->identityValue;
+	}//end getIdentityValue()
+}//end class

--- a/lib/Event/RegistrySubscriptionRequestedEvent.php
+++ b/lib/Event/RegistrySubscriptionRequestedEvent.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * OpenRegister RegistrySubscriptionRequestedEvent
+ *
+ * Cross-app command event (finding B22): dispatched when a user with
+ * `update` on an object requests a registry subscription. OpenRegister
+ * does NOT talk to BRP or KvK itself and does NOT call integriq directly
+ * (direct cross-app RPC is gate-27-forbidden) — it only carries the
+ * request. A connector app (integriq) registers an IEventListener for this
+ * event and turns it into a live subscription at the source, then reports
+ * back through the inbound update endpoint.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Event
+ * @package  OCA\OpenRegister\Event
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Event dispatched to request a registry subscription on an object.
+ *
+ * Carries the triggering object's uuid/register/schema, the registry id
+ * (`brp`, `kvk`, ...) and the identity value (BSN, KvK number, ...) a
+ * connector needs to establish the subscription at the source.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+class RegistrySubscriptionRequestedEvent extends Event {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $objectUuid UUID of the object requesting a subscription.
+	 * @param string $register Register slug/id the object lives in.
+	 * @param string $schema Schema slug/id the object was saved against.
+	 * @param string $registry The registry id (`brp`, `kvk`, ...).
+	 * @param string $identityValue The object's identity value at that registry.
+	 */
+	public function __construct(
+		private readonly string $objectUuid,
+		private readonly string $register,
+		private readonly string $schema,
+		private readonly string $registry,
+		private readonly string $identityValue,
+	) {
+		parent::__construct();
+	}//end __construct()
+
+	/**
+	 * Get the triggering object's UUID.
+	 *
+	 * @return string
+	 */
+	public function getObjectUuid(): string {
+		return $this->objectUuid;
+	}//end getObjectUuid()
+
+	/**
+	 * Get the triggering object's register slug/id.
+	 *
+	 * @return string
+	 */
+	public function getRegister(): string {
+		return $this->register;
+	}//end getRegister()
+
+	/**
+	 * Get the triggering object's schema slug/id.
+	 *
+	 * @return string
+	 */
+	public function getSchema(): string {
+		return $this->schema;
+	}//end getSchema()
+
+	/**
+	 * Get the registry id (`brp`, `kvk`, ...).
+	 *
+	 * @return string
+	 */
+	public function getRegistry(): string {
+		return $this->registry;
+	}//end getRegistry()
+
+	/**
+	 * Get the object's identity value at the registry.
+	 *
+	 * @return string
+	 */
+	public function getIdentityValue(): string {
+		return $this->identityValue;
+	}//end getIdentityValue()
+
+	/**
+	 * Flatten for a job boundary / CloudEvent payload.
+	 *
+	 * @return array<string, string>
+	 */
+	public function getPayload(): array {
+		return [
+			'objectUuid' => $this->objectUuid,
+			'register' => $this->register,
+			'schema' => $this->schema,
+			'registry' => $this->registry,
+			'identityValue' => $this->identityValue,
+		];
+	}//end getPayload()
+}//end class

--- a/lib/Migration/Version1Date20260911170000.php
+++ b/lib/Migration/Version1Date20260911170000.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * The registry-subscriptions state table (finding B22): one row per object
+ * that has requested a registry subscription (`x-openregister-registry`),
+ * keyed by object uuid, per design.md D-2 of `registry-subscriptions`.
+ *
+ * Deliberately NOT a copy of the subscribed person or company. The object
+ * OpenRegister already holds — in whichever app's register declared the
+ * schema — stays the only copy; this table is bookkeeping about its
+ * subscription state, not a second store of its data.
+ *
+ * `registry` + `identity_value` is NOT unique: two different objects (in
+ * different registers, e.g. two apps each keeping their own `person`
+ * schema) may legitimately subscribe to the same real-world BSN or KvK
+ * number, and the inbound update endpoint updates every matching active
+ * row, not just one.
+ *
+ * @category Migration
+ * @package  OCA\OpenRegister\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://OpenRegister.app
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Creates the registry subscription state table.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+ */
+class Version1Date20260911170000 extends SimpleMigrationStep {
+
+	/**
+	 * The registry subscription state table.
+	 */
+	private const TABLE = 'openregister_registry_subs';
+
+	/**
+	 * Create the table when absent.
+	 *
+	 * @param IOutput $output Migration output.
+	 * @param Closure $schemaClosure Returns the schema wrapper.
+	 * @param array<string, mixed> $options Migration options.
+	 *
+	 * @return ISchemaWrapper|null The changed schema, or null when nothing changed.
+	 *
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter) The signature is Nextcloud's.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable(self::TABLE) === true) {
+			return null;
+		}
+
+		$table = $schema->createTable(self::TABLE);
+		$table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'notnull' => true]);
+		$table->addColumn('object_uuid', Types::STRING, ['notnull' => true, 'length' => 36]);
+		$table->addColumn('register', Types::STRING, ['notnull' => true, 'length' => 64]);
+		$table->addColumn('schema', Types::STRING, ['notnull' => true, 'length' => 64]);
+		$table->addColumn('registry', Types::STRING, ['notnull' => true, 'length' => 64]);
+		$table->addColumn('identity_value', Types::STRING, ['notnull' => true, 'length' => 255]);
+		// One of: none, requested, active, ended.
+		$table->addColumn('state', Types::STRING, ['notnull' => true, 'length' => 16, 'default' => 'none']);
+		$table->addColumn('last_update_at', Types::DATETIME_MUTABLE, ['notnull' => false]);
+		$table->addColumn('last_update_source', Types::STRING, ['notnull' => false, 'length' => 255]);
+		$table->addColumn('refusal_reason', Types::TEXT, ['notnull' => false]);
+		$table->addColumn('created_at', Types::DATETIME_MUTABLE, ['notnull' => true]);
+		$table->addColumn('updated_at', Types::DATETIME_MUTABLE, ['notnull' => true]);
+
+		$table->setPrimaryKey(['id']);
+		// One subscription row per object: requesting again updates the row.
+		$table->addUniqueIndex(['object_uuid'], 'or_registry_sub_object');
+		// The inbound endpoint's lookup path: every object subscribed to a
+		// given registry+identity, filtered to active rows.
+		$table->addIndex(['registry', 'identity_value', 'state'], 'or_registry_sub_lookup');
+		// The `_registry[state]` / `_registry[updatedBefore]` query lenses.
+		$table->addIndex(['state', 'last_update_at'], 'or_registry_sub_state_updated');
+
+		return $schema;
+	}//end changeSchema()
+}//end class

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -51,6 +51,7 @@ use OCA\OpenRegister\Service\ObjectSource\ObjectSourceRegistry;
 use OCA\OpenRegister\Service\PropertyRbacHandler;
 use OCA\OpenRegister\Service\SystemOperationContext;
 use OCA\OpenRegister\Service\TranslationStatusService;
+use OCA\OpenRegister\Service\Registry\RegistrySubscriptionService;
 use OCA\OpenRegister\Service\UrnService;
 use OCP\IRequest;
 use OCP\SystemTag\ISystemTagManager;
@@ -190,6 +191,7 @@ class RenderObject {
 	 * @param IRequest|null $request Current request, used to read `?recurrenceOccurrences=N`.
 	 * @param ObjectSourceRegistry|null $objectSourceRegistry Resolves object-source providers for `$ref` extends into virtual schemas.
 	 * @param FieldEncryptionHandler|null $fieldEncryptionHandler Field-level encryption handler (x-openregister-encrypted).
+	 * @param RegistrySubscriptionService|null $registrySubscriptionService Materialises `@self.registry` (registry-subscriptions).
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) All parameters are DI-injected dependencies
 	 *
@@ -219,6 +221,7 @@ class RenderObject {
 		private readonly ?IRequest $request = null,
 		private readonly ?ObjectSourceRegistry $objectSourceRegistry = null,
 		private readonly ?FieldEncryptionHandler $fieldEncryptionHandler = null,
+		private readonly ?RegistrySubscriptionService $registrySubscriptionService = null,
 	) {
 	}//end __construct()
 
@@ -2091,6 +2094,32 @@ class RenderObject {
 			$this->logger->debug(
 				sprintf(
 					'[RenderObject] translation completeness lookup failed for %s: %s',
+					(string)$entity->getUuid(),
+					$e->getMessage()
+				)
+			);
+		}
+
+		// Registry subscription state (`registry-subscriptions`, finding
+		// B22). Only looked up when the schema actually declares
+		// `x-openregister-registry` — a cheap in-memory check on the
+		// already-loaded schema — so the common case (no annotation) costs
+		// no extra query per rendered row.
+		try {
+			if ($this->registrySubscriptionService !== null
+				&& $renderSchema !== null
+				&& $entity->getUuid() !== null
+				&& $this->registrySubscriptionService->annotationFor(schema: $renderSchema) !== null
+			) {
+				$registryState = $this->registrySubscriptionService->stateFor((string)$entity->getUuid());
+				if ($registryState !== null) {
+					$entity->setRegistryState($registryState);
+				}
+			}
+		} catch (\Throwable $e) {
+			$this->logger->debug(
+				sprintf(
+					'[RenderObject] registry subscription state lookup failed for %s: %s',
 					(string)$entity->getUuid(),
 					$e->getMessage()
 				)

--- a/lib/Service/Object/RenderObject.php
+++ b/lib/Service/Object/RenderObject.php
@@ -52,6 +52,7 @@ use OCA\OpenRegister\Service\PropertyRbacHandler;
 use OCA\OpenRegister\Service\SystemOperationContext;
 use OCA\OpenRegister\Service\TranslationStatusService;
 use OCA\OpenRegister\Service\Registry\RegistrySubscriptionService;
+use Psr\Container\ContainerInterface;
 use OCA\OpenRegister\Service\UrnService;
 use OCP\IRequest;
 use OCP\SystemTag\ISystemTagManager;
@@ -191,7 +192,11 @@ class RenderObject {
 	 * @param IRequest|null $request Current request, used to read `?recurrenceOccurrences=N`.
 	 * @param ObjectSourceRegistry|null $objectSourceRegistry Resolves object-source providers for `$ref` extends into virtual schemas.
 	 * @param FieldEncryptionHandler|null $fieldEncryptionHandler Field-level encryption handler (x-openregister-encrypted).
-	 * @param RegistrySubscriptionService|null $registrySubscriptionService Materialises `@self.registry` (registry-subscriptions).
+	 * @param ContainerInterface|null $container Lazily resolves RegistrySubscriptionService
+	 *        (registry-subscriptions) — NOT constructor-injected directly: that dependency
+	 *        chains ObjectService -> RenderObject -> RegistrySubscriptionService -> ObjectService,
+	 *        a cycle Nextcloud's container refuses to construct eagerly. Same lazy-resolution
+	 *        pattern PermissionHandler already uses for the same reason.
 	 *
 	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) All parameters are DI-injected dependencies
 	 *
@@ -221,7 +226,7 @@ class RenderObject {
 		private readonly ?IRequest $request = null,
 		private readonly ?ObjectSourceRegistry $objectSourceRegistry = null,
 		private readonly ?FieldEncryptionHandler $fieldEncryptionHandler = null,
-		private readonly ?RegistrySubscriptionService $registrySubscriptionService = null,
+		private readonly ?ContainerInterface $container = null,
 	) {
 	}//end __construct()
 
@@ -2106,14 +2111,13 @@ class RenderObject {
 		// already-loaded schema — so the common case (no annotation) costs
 		// no extra query per rendered row.
 		try {
-			if ($this->registrySubscriptionService !== null
-				&& $renderSchema !== null
-				&& $entity->getUuid() !== null
-				&& $this->registrySubscriptionService->annotationFor(schema: $renderSchema) !== null
-			) {
-				$registryState = $this->registrySubscriptionService->stateFor((string)$entity->getUuid());
-				if ($registryState !== null) {
-					$entity->setRegistryState($registryState);
+			if ($this->container !== null && $renderSchema !== null && $entity->getUuid() !== null) {
+				$registrySubscriptions = $this->container->get(RegistrySubscriptionService::class);
+				if ($registrySubscriptions->annotationFor(schema: $renderSchema) !== null) {
+					$registryState = $registrySubscriptions->stateFor((string)$entity->getUuid());
+					if ($registryState !== null) {
+						$entity->setRegistryState($registryState);
+					}
 				}
 			}
 		} catch (\Throwable $e) {

--- a/lib/Service/Registry/RegistryAnnotationValidator.php
+++ b/lib/Service/Registry/RegistryAnnotationValidator.php
@@ -74,41 +74,89 @@ final class RegistryAnnotationValidator {
 			$properties = [];
 		}
 
-		$errors = [];
+		return array_merge(
+			$this->validateRegistryId(annotation: $annotation),
+			$this->validateIdentity(annotation: $annotation, properties: $properties),
+			$this->validateOwned(annotation: $annotation, properties: $properties)
+		);
+	}//end validate()
 
-		$registry = (string)($annotation['registry'] ?? '');
-		if ($registry === '') {
-			$errors[] = [
+	/**
+	 * Validate `x-openregister-registry.registry`.
+	 *
+	 * @param array<string, mixed> $annotation The annotation block.
+	 *
+	 * @return array<int, array{code: string, message: string}>
+	 */
+	private function validateRegistryId(array $annotation): array {
+		if ((string)($annotation['registry'] ?? '') !== '') {
+			return [];
+		}
+
+		return [
+			[
 				'code' => 'registry-id-missing',
 				'message' => 'x-openregister-registry.registry must be a non-empty string.',
+			],
+		];
+	}//end validateRegistryId()
+
+	/**
+	 * Validate `x-openregister-registry.identity` is non-empty and declared
+	 * in the schema's own properties.
+	 *
+	 * @param array<string, mixed> $annotation The annotation block.
+	 * @param array<string, mixed> $properties The schema's own properties.
+	 *
+	 * @return array<int, array{code: string, message: string}>
+	 */
+	private function validateIdentity(array $annotation, array $properties): array {
+		$identity = (string)($annotation['identity'] ?? '');
+		if ($identity === '') {
+			return [
+				[
+					'code' => 'registry-identity-missing',
+					'message' => 'x-openregister-registry.identity must be a non-empty string.',
+				],
 			];
 		}
 
-		$identity = (string)($annotation['identity'] ?? '');
-		if ($identity === '') {
-			$errors[] = [
-				'code' => 'registry-identity-missing',
-				'message' => 'x-openregister-registry.identity must be a non-empty string.',
-			];
-		} elseif (array_key_exists($identity, $properties) === false) {
-			$errors[] = [
+		if (array_key_exists($identity, $properties) === true) {
+			return [];
+		}
+
+		return [
+			[
 				'code' => 'registry-identity-undeclared',
 				'message' => sprintf(
 					'x-openregister-registry.identity "%s" is not declared in this schema\'s properties.',
 					$identity
 				),
-			];
-		}
+			],
+		];
+	}//end validateIdentity()
 
+	/**
+	 * Validate `x-openregister-registry.owned`: a non-empty array of
+	 * non-empty strings, each declared in the schema's own properties.
+	 *
+	 * @param array<string, mixed> $annotation The annotation block.
+	 * @param array<string, mixed> $properties The schema's own properties.
+	 *
+	 * @return array<int, array{code: string, message: string}>
+	 */
+	private function validateOwned(array $annotation, array $properties): array {
 		$owned = $annotation['owned'] ?? null;
 		if (is_array($owned) === false || count($owned) === 0) {
-			$errors[] = [
-				'code' => 'registry-owned-missing',
-				'message' => 'x-openregister-registry.owned must be a non-empty array of property names.',
+			return [
+				[
+					'code' => 'registry-owned-missing',
+					'message' => 'x-openregister-registry.owned must be a non-empty array of property names.',
+				],
 			];
-			return $errors;
 		}
 
+		$errors = [];
 		foreach ($owned as $index => $property) {
 			if (is_string($property) === false || $property === '') {
 				$errors[] = [
@@ -130,5 +178,5 @@ final class RegistryAnnotationValidator {
 		}
 
 		return $errors;
-	}//end validate()
+	}//end validateOwned()
 }//end class

--- a/lib/Service/Registry/RegistryAnnotationValidator.php
+++ b/lib/Service/Registry/RegistryAnnotationValidator.php
@@ -53,6 +53,8 @@ final class RegistryAnnotationValidator {
 	 *                                     `x-openregister-registry`.
 	 *
 	 * @return array<int, array{code: string, message: string}>
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-a-schema-declares-which-registry-owns-which-properties
 	 */
 	public function validate(array $schema): array {
 		if (isset($schema['x-openregister-registry']) === false) {

--- a/lib/Service/Registry/RegistryAnnotationValidator.php
+++ b/lib/Service/Registry/RegistryAnnotationValidator.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * OpenRegister RegistryAnnotationValidator
+ *
+ * Schema-save validation for the `x-openregister-registry` annotation.
+ * Returns a list of errors; empty = valid.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Registry
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Registry;
+
+/**
+ * Validates the `x-openregister-registry` schema annotation shape.
+ *
+ * The annotation names an external registry (`brp`, `kvk`, or another id),
+ * the property that carries the identity value the registry looks the
+ * object up by (`bsn`, `kvkNumber`), and the properties the registry is
+ * allowed to write on an inbound update:
+ *
+ *   { registry: string, identity: string, owned: string[] }
+ *
+ * `identity` and every entry of `owned` MUST be declared in the schema's
+ * own `properties`. Schema save refuses the annotation otherwise (per
+ * `registry-subscriptions` REQ 1) — this validator's errors are treated as
+ * BLOCKING by the caller (`SchemaMapper::validateRegistryAnnotation()`),
+ * unlike most other `x-openregister-*` validators, which only warn.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
+ */
+final class RegistryAnnotationValidator {
+
+	/**
+	 * Validate the registry annotation.
+	 *
+	 * @param array<string, mixed> $schema Full schema definition, including
+	 *                                     `properties` and
+	 *                                     `x-openregister-registry`.
+	 *
+	 * @return array<int, array{code: string, message: string}>
+	 */
+	public function validate(array $schema): array {
+		if (isset($schema['x-openregister-registry']) === false) {
+			return [];
+		}
+
+		$annotation = $schema['x-openregister-registry'];
+		if (is_array($annotation) === false) {
+			return [
+				[
+					'code' => 'registry-malformed',
+					'message' => 'x-openregister-registry must be an object.',
+				],
+			];
+		}
+
+		$properties = $schema['properties'] ?? [];
+		if (is_array($properties) === false) {
+			$properties = [];
+		}
+
+		$errors = [];
+
+		$registry = (string)($annotation['registry'] ?? '');
+		if ($registry === '') {
+			$errors[] = [
+				'code' => 'registry-id-missing',
+				'message' => 'x-openregister-registry.registry must be a non-empty string.',
+			];
+		}
+
+		$identity = (string)($annotation['identity'] ?? '');
+		if ($identity === '') {
+			$errors[] = [
+				'code' => 'registry-identity-missing',
+				'message' => 'x-openregister-registry.identity must be a non-empty string.',
+			];
+		} elseif (array_key_exists($identity, $properties) === false) {
+			$errors[] = [
+				'code' => 'registry-identity-undeclared',
+				'message' => sprintf(
+					'x-openregister-registry.identity "%s" is not declared in this schema\'s properties.',
+					$identity
+				),
+			];
+		}
+
+		$owned = $annotation['owned'] ?? null;
+		if (is_array($owned) === false || count($owned) === 0) {
+			$errors[] = [
+				'code' => 'registry-owned-missing',
+				'message' => 'x-openregister-registry.owned must be a non-empty array of property names.',
+			];
+			return $errors;
+		}
+
+		foreach ($owned as $index => $property) {
+			if (is_string($property) === false || $property === '') {
+				$errors[] = [
+					'code' => 'registry-owned-malformed',
+					'message' => sprintf('x-openregister-registry.owned[%s] must be a non-empty string.', (string)$index),
+				];
+				continue;
+			}
+
+			if (array_key_exists($property, $properties) === false) {
+				$errors[] = [
+					'code' => 'registry-owned-undeclared',
+					'message' => sprintf(
+						'x-openregister-registry.owned property "%s" is not declared in this schema\'s properties.',
+						$property
+					),
+				];
+			}
+		}
+
+		return $errors;
+	}//end validate()
+}//end class

--- a/lib/Service/Registry/RegistryOwnedPropertyGuard.php
+++ b/lib/Service/Registry/RegistryOwnedPropertyGuard.php
@@ -45,6 +45,8 @@ final class RegistryOwnedPropertyGuard {
 	 *         is true only when every key of `$supplied` is in `$owned`.
 	 *         `rejected` names every offending key, so the 422 response can
 	 *         name all of them at once rather than only the first.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
 	 */
 	public function check(array $owned, array $supplied): array {
 		$ownedSet = array_flip($owned);

--- a/lib/Service/Registry/RegistryOwnedPropertyGuard.php
+++ b/lib/Service/Registry/RegistryOwnedPropertyGuard.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * OpenRegister RegistryOwnedPropertyGuard
+ *
+ * Pure decision logic for `registry-subscriptions` REQ 3: an inbound
+ * registry update may only touch properties the schema's
+ * `x-openregister-registry.owned` list names. Deliberately framework-free
+ * (no Nextcloud/DB classes) so the 422-vs-apply decision is unit-testable
+ * without booting a Nextcloud container.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Registry
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Registry;
+
+/**
+ * Decides whether a supplied set of inbound properties may be applied.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
+ */
+final class RegistryOwnedPropertyGuard {
+
+	/**
+	 * Check a supplied property set against the schema's owned list.
+	 *
+	 * @param array<int, string>   $owned    Property names the registry may write.
+	 * @param array<string, mixed> $supplied The properties the inbound update carries.
+	 *
+	 * @return array{allowed: bool, rejected: array<int, string>} `allowed`
+	 *         is true only when every key of `$supplied` is in `$owned`.
+	 *         `rejected` names every offending key, so the 422 response can
+	 *         name all of them at once rather than only the first.
+	 */
+	public function check(array $owned, array $supplied): array {
+		$ownedSet = array_flip($owned);
+
+		$rejected = [];
+		foreach (array_keys($supplied) as $property) {
+			if (isset($ownedSet[$property]) === false) {
+				$rejected[] = (string)$property;
+			}
+		}
+
+		return [
+			'allowed' => (count($rejected) === 0),
+			'rejected' => $rejected,
+		];
+	}//end check()
+}//end class

--- a/lib/Service/Registry/RegistrySubscriptionNotifier.php
+++ b/lib/Service/Registry/RegistrySubscriptionNotifier.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * OpenRegister RegistrySubscriptionNotifier
+ *
+ * Bundles the event-dispatch and audit-trail side effects of a registry
+ * subscription action behind one small collaborator, so
+ * {@see RegistrySubscriptionService} depends on this instead of directly on
+ * `IEventDispatcher`, `AuditTrailMapper` and both event classes. Extracted
+ * to keep that service's coupling under this repo's PHPMD threshold — a
+ * mechanical constraint, but one that also names a real seam: "how does a
+ * subscription action get announced" is one concern, separate from "what
+ * counts as a valid subscription state transition".
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Registry
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Registry;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\RegistrySubscriptionEndedEvent;
+use OCA\OpenRegister\Event\RegistrySubscriptionRequestedEvent;
+use OCP\EventDispatcher\IEventDispatcher;
+
+/**
+ * Dispatches the connector-facing events and writes the audit rows for a
+ * registry subscription action.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
+ */
+class RegistrySubscriptionNotifier {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param IEventDispatcher $eventDispatcher Dispatches the connector-facing events.
+	 * @param AuditTrailMapper $auditTrailMapper Writes the audit rows.
+	 */
+	public function __construct(
+		private readonly IEventDispatcher $eventDispatcher,
+		private readonly AuditTrailMapper $auditTrailMapper,
+	) {
+	}//end __construct()
+
+	/**
+	 * Announce a subscription request: dispatch the connector event and
+	 * audit it against the session user.
+	 *
+	 * @param ObjectEntity $object The object requesting a subscription.
+	 * @param string $register Register slug/id the object lives in.
+	 * @param string $schema Schema slug/id the object was saved against.
+	 * @param string $registry The registry id (`brp`, `kvk`, ...).
+	 * @param string $identityValue The object's identity value at that registry.
+	 *
+	 * @return void
+	 */
+	public function requested(ObjectEntity $object, string $register, string $schema, string $registry, string $identityValue): void {
+		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionRequestedEvent(
+			objectUuid: (string)$object->getUuid(),
+			register: $register,
+			schema: $schema,
+			registry: $registry,
+			identityValue: $identityValue,
+		));
+
+		$this->auditTrailMapper->createAuditTrailEntry(
+			object: $object,
+			action: 'registry.subscription.requested',
+			context: ['registry' => $registry],
+		);
+	}//end requested()
+
+	/**
+	 * Announce a subscription end: dispatch the connector event and audit
+	 * it against the session user.
+	 *
+	 * @param ObjectEntity $object The object ending its subscription.
+	 * @param string $registry The registry id (`brp`, `kvk`, ...).
+	 * @param string $identityValue The object's identity value at that registry.
+	 *
+	 * @return void
+	 */
+	public function ended(ObjectEntity $object, string $registry, string $identityValue): void {
+		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionEndedEvent(
+			objectUuid: (string)$object->getUuid(),
+			registry: $registry,
+			identityValue: $identityValue,
+		));
+
+		$this->auditTrailMapper->createAuditTrailEntry(
+			object: $object,
+			action: 'registry.subscription.ended',
+			context: ['registry' => $registry],
+		);
+	}//end ended()
+
+	/**
+	 * Audit an applied inbound update with the REGISTRY as actor — see
+	 * `RegistrySubscriptionService::applyInboundUpdate()` for why this is a
+	 * second, explicit row rather than relying on the ordinary save path's
+	 * own session-derived audit entry.
+	 *
+	 * @param ObjectEntity $object The updated object.
+	 * @param string $registry The registry id (`brp`, `kvk`, ...).
+	 * @param string $eventReference The registry's own event reference for this change.
+	 * @param array<int, string> $properties The property names that were changed.
+	 *
+	 * @return void
+	 */
+	public function auditInboundUpdate(ObjectEntity $object, string $registry, string $eventReference, array $properties): void {
+		$this->auditTrailMapper->createAuditTrailEntry(
+			object: $object,
+			action: 'registry.update',
+			context: ['registry' => $registry, 'eventReference' => $eventReference, 'properties' => $properties],
+			actorId: 'registry:' . $registry,
+			actorName: 'Registry (' . $registry . ')',
+		);
+	}//end auditInboundUpdate()
+}//end class

--- a/lib/Service/Registry/RegistrySubscriptionNotifier.php
+++ b/lib/Service/Registry/RegistrySubscriptionNotifier.php
@@ -68,6 +68,8 @@ class RegistrySubscriptionNotifier {
 	 * @param string $identityValue The object's identity value at that registry.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
 	 */
 	public function requested(ObjectEntity $object, string $register, string $schema, string $registry, string $identityValue): void {
 		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionRequestedEvent(
@@ -94,6 +96,8 @@ class RegistrySubscriptionNotifier {
 	 * @param string $identityValue The object's identity value at that registry.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
 	 */
 	public function ended(ObjectEntity $object, string $registry, string $identityValue): void {
 		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionEndedEvent(
@@ -121,6 +125,8 @@ class RegistrySubscriptionNotifier {
 	 * @param array<int, string> $properties The property names that were changed.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
 	 */
 	public function auditInboundUpdate(ObjectEntity $object, string $registry, string $eventReference, array $properties): void {
 		$this->auditTrailMapper->createAuditTrailEntry(

--- a/lib/Service/Registry/RegistrySubscriptionService.php
+++ b/lib/Service/Registry/RegistrySubscriptionService.php
@@ -35,14 +35,10 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegistrySubscription;
 use OCA\OpenRegister\Db\RegistrySubscriptionMapper;
 use OCA\OpenRegister\Db\Schema;
-use OCA\OpenRegister\Db\SchemaMapper;
-use OCA\OpenRegister\Db\AuditTrailMapper;
-use OCA\OpenRegister\Event\RegistrySubscriptionEndedEvent;
-use OCA\OpenRegister\Event\RegistrySubscriptionRequestedEvent;
 use OCA\OpenRegister\Service\ObjectService;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\EventDispatcher\IEventDispatcher;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Coordinates the registry subscription lifecycle and the inbound update.
@@ -55,20 +51,16 @@ class RegistrySubscriptionService {
 	 * Constructor.
 	 *
 	 * @param RegistrySubscriptionMapper $subscriptionMapper Reads/writes the state table.
-	 * @param SchemaMapper $schemaMapper Resolves a schema's `x-openregister-registry` annotation.
 	 * @param ObjectService $objectService Applies inbound updates through the ordinary save path.
-	 * @param AuditTrailMapper $auditTrailMapper Writes the audit rows, including the connector-actor one.
-	 * @param IEventDispatcher $eventDispatcher Dispatches the request/end events for the connector.
-	 * @param RegistryOwnedPropertyGuard $ownedPropertyGuard The pure owned-vs-supplied decision.
+	 * @param RegistrySubscriptionNotifier $notifier Dispatches events and writes audit rows.
+	 * @param RegistryUpdateTargetGuard $updateTargetGuard Resolves a row's schema and checks owned properties.
 	 * @param LoggerInterface $logger Structured logging.
 	 */
 	public function __construct(
 		private readonly RegistrySubscriptionMapper $subscriptionMapper,
-		private readonly SchemaMapper $schemaMapper,
 		private readonly ObjectService $objectService,
-		private readonly AuditTrailMapper $auditTrailMapper,
-		private readonly IEventDispatcher $eventDispatcher,
-		private readonly RegistryOwnedPropertyGuard $ownedPropertyGuard,
+		private readonly RegistrySubscriptionNotifier $notifier,
+		private readonly RegistryUpdateTargetGuard $updateTargetGuard,
 		private readonly LoggerInterface $logger,
 	) {
 	}//end __construct()
@@ -149,18 +141,12 @@ class RegistrySubscriptionService {
 		$row->setUpdatedAt($now);
 		$row = $this->subscriptionMapper->save(subscription: $row);
 
-		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionRequestedEvent(
-			objectUuid: $uuid,
+		$this->notifier->requested(
+			object: $object,
 			register: (string)$object->getRegister(),
 			schema: (string)$object->getSchema(),
 			registry: $annotation['registry'],
 			identityValue: $identityValue,
-		));
-
-		$this->auditTrailMapper->createAuditTrailEntry(
-			object: $object,
-			action: 'registry.subscription.requested',
-			context: ['registry' => $annotation['registry']],
 		);
 
 		return $row;
@@ -189,16 +175,10 @@ class RegistrySubscriptionService {
 		$row->setUpdatedAt(new DateTime());
 		$row = $this->subscriptionMapper->save(subscription: $row);
 
-		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionEndedEvent(
-			objectUuid: $uuid,
+		$this->notifier->ended(
+			object: $object,
 			registry: (string)$row->getRegistry(),
 			identityValue: (string)$row->getIdentityValue(),
-		));
-
-		$this->auditTrailMapper->createAuditTrailEntry(
-			object: $object,
-			action: 'registry.subscription.ended',
-			context: ['registry' => $row->getRegistry()],
 		);
 
 		return $row;
@@ -241,18 +221,7 @@ class RegistrySubscriptionService {
 		$rejected = [];
 
 		foreach ($rows as $row) {
-			$schema = $this->schemaMapper->find(id: (string)$row->getSchema());
-			$annotation = $this->annotationFor(schema: $schema);
-			if ($annotation === null) {
-				// The schema's annotation was removed after the subscription
-				// was requested. Treat exactly like an owned-property
-				// violation: refuse rather than silently apply an
-				// unauthorised write.
-				$rejected[] = ['objectUuid' => (string)$row->getObjectUuid(), 'properties' => array_keys($properties)];
-				continue;
-			}
-
-			$guardResult = $this->ownedPropertyGuard->check(owned: $annotation['owned'], supplied: $properties);
+			$guardResult = $this->updateTargetGuard->evaluate(row: $row, properties: $properties);
 			if ($guardResult['allowed'] === false) {
 				$rejected[] = ['objectUuid' => (string)$row->getObjectUuid(), 'properties' => $guardResult['rejected']];
 				continue;
@@ -271,7 +240,7 @@ class RegistrySubscriptionService {
 					schema: $row->getSchema(),
 					uuid: $row->getObjectUuid(),
 				);
-			} catch (\Throwable $e) {
+			} catch (Throwable $e) {
 				$this->logger->error(
 					'[OpenRegister.RegistrySubscriptionService] Inbound update failed to save for object '
 					. $row->getObjectUuid() . ': ' . $e->getMessage()
@@ -291,15 +260,14 @@ class RegistrySubscriptionService {
 			// saveObject()'s own audit trail already recorded this write
 			// with whichever Nextcloud account the connector's app password
 			// belongs to (the ordinary save path's session-derived actor);
-			// this row is the one `registry-subscriptions` REQ 3 asks for —
-			// "the audit entry names registry `brp` as actor" — independent
+			// this row is the one `registry-subscriptions` REQ 3 asks for:
+			// "the audit entry names registry `brp` as actor", independent
 			// of which account backs the connector's credential.
-			$this->auditTrailMapper->createAuditTrailEntry(
+			$this->notifier->auditInboundUpdate(
 				object: $updated,
-				action: 'registry.update',
-				context: ['registry' => $registry, 'eventReference' => $eventReference, 'properties' => array_keys($properties)],
-				actorId: 'registry:' . $registry,
-				actorName: 'Registry (' . $registry . ')',
+				registry: $registry,
+				eventReference: $eventReference,
+				properties: array_keys($properties),
 			);
 
 			$applied[] = (string)$row->getObjectUuid();

--- a/lib/Service/Registry/RegistrySubscriptionService.php
+++ b/lib/Service/Registry/RegistrySubscriptionService.php
@@ -1,0 +1,346 @@
+<?php
+
+/**
+ * OpenRegister RegistrySubscriptionService
+ *
+ * Implements `registry-subscriptions` (finding B22): a user with `update`
+ * on an object of a schema declaring `x-openregister-registry` can request
+ * or end a subscription; a connector app (integriq) turns a request into a
+ * live subscription and posts changes back through
+ * {@see applyInboundUpdate()}. OpenRegister holds no copy of the
+ * subscribed person or company beyond the object it already stores.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Registry
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Registry;
+
+use DateTime;
+use InvalidArgumentException;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegistrySubscription;
+use OCA\OpenRegister\Db\RegistrySubscriptionMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Event\RegistrySubscriptionEndedEvent;
+use OCA\OpenRegister\Event\RegistrySubscriptionRequestedEvent;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\IEventDispatcher;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Coordinates the registry subscription lifecycle and the inbound update.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
+ */
+class RegistrySubscriptionService {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param RegistrySubscriptionMapper $subscriptionMapper Reads/writes the state table.
+	 * @param SchemaMapper $schemaMapper Resolves a schema's `x-openregister-registry` annotation.
+	 * @param ObjectService $objectService Applies inbound updates through the ordinary save path.
+	 * @param AuditTrailMapper $auditTrailMapper Writes the audit rows, including the connector-actor one.
+	 * @param IEventDispatcher $eventDispatcher Dispatches the request/end events for the connector.
+	 * @param RegistryOwnedPropertyGuard $ownedPropertyGuard The pure owned-vs-supplied decision.
+	 * @param LoggerInterface $logger Structured logging.
+	 */
+	public function __construct(
+		private readonly RegistrySubscriptionMapper $subscriptionMapper,
+		private readonly SchemaMapper $schemaMapper,
+		private readonly ObjectService $objectService,
+		private readonly AuditTrailMapper $auditTrailMapper,
+		private readonly IEventDispatcher $eventDispatcher,
+		private readonly RegistryOwnedPropertyGuard $ownedPropertyGuard,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Read a schema's `x-openregister-registry` annotation, or null when the
+	 * schema does not declare one.
+	 *
+	 * @param Schema $schema The schema to read.
+	 *
+	 * @return array{registry: string, identity: string, owned: array<int, string>}|null
+	 */
+	public function annotationFor(Schema $schema): ?array {
+		$configuration = ($schema->getConfiguration() ?? []);
+		$annotation = ($configuration['x-openregister-registry'] ?? null);
+		if (is_array($annotation) === false) {
+			return null;
+		}
+
+		$owned = $annotation['owned'] ?? [];
+		if (is_array($owned) === false) {
+			$owned = [];
+		}
+
+		return [
+			'registry' => (string)($annotation['registry'] ?? ''),
+			'identity' => (string)($annotation['identity'] ?? ''),
+			'owned' => array_values(array_map('strval', $owned)),
+		];
+	}//end annotationFor()
+
+	/**
+	 * Request a subscription on an object. Caller MUST have already checked
+	 * the requesting user has `update` on `$object` — this service does not
+	 * re-check permission (per this codebase's Controller -> Service ->
+	 * Mapper layering; the per-object IDOR guard belongs in the controller).
+	 *
+	 * @param ObjectEntity $object The object to subscribe.
+	 * @param Schema $schema The object's schema (must declare `x-openregister-registry`).
+	 *
+	 * @return RegistrySubscription The persisted row.
+	 *
+	 * @throws InvalidArgumentException When the schema declares no registry annotation,
+	 *                                  or the object has no value for the identity property.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+	 */
+	public function requestSubscription(ObjectEntity $object, Schema $schema): RegistrySubscription {
+		$annotation = $this->annotationFor(schema: $schema);
+		if ($annotation === null) {
+			throw new InvalidArgumentException(
+				'Schema "' . ((string)$schema->getSlug()) . '" does not declare x-openregister-registry.'
+			);
+		}
+
+		$identityValue = (string)($object->getObject()[$annotation['identity']] ?? '');
+		if ($identityValue === '') {
+			throw new InvalidArgumentException(
+				'Object has no value for identity property "' . $annotation['identity'] . '".'
+			);
+		}
+
+		$uuid = (string)$object->getUuid();
+		$row = $this->subscriptionMapper->findForObject(objectUuid: $uuid);
+		$now = new DateTime();
+		if ($row === null) {
+			$row = new RegistrySubscription();
+			$row->setObjectUuid($uuid);
+			$row->setCreatedAt($now);
+		}
+
+		$row->setRegister((string)$object->getRegister());
+		$row->setSchema((string)$object->getSchema());
+		$row->setRegistry($annotation['registry']);
+		$row->setIdentityValue($identityValue);
+		$row->setState(RegistrySubscription::STATE_REQUESTED);
+		$row->setRefusalReason(null);
+		$row->setUpdatedAt($now);
+		$row = $this->subscriptionMapper->save(subscription: $row);
+
+		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionRequestedEvent(
+			objectUuid: $uuid,
+			register: (string)$object->getRegister(),
+			schema: (string)$object->getSchema(),
+			registry: $annotation['registry'],
+			identityValue: $identityValue,
+		));
+
+		$this->auditTrailMapper->createAuditTrailEntry(
+			object: $object,
+			action: 'registry.subscription.requested',
+			context: ['registry' => $annotation['registry']],
+		);
+
+		return $row;
+	}//end requestSubscription()
+
+	/**
+	 * End a subscription on an object. Caller MUST have already checked the
+	 * requesting user has `update` on `$object`.
+	 *
+	 * @param ObjectEntity $object The object to unsubscribe.
+	 *
+	 * @return RegistrySubscription The persisted row.
+	 *
+	 * @throws DoesNotExistException When the object never had a subscription row.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
+	 */
+	public function endSubscription(ObjectEntity $object): RegistrySubscription {
+		$uuid = (string)$object->getUuid();
+		$row = $this->subscriptionMapper->findForObject(objectUuid: $uuid);
+		if ($row === null) {
+			throw new DoesNotExistException('Object "' . $uuid . '" has no registry subscription.');
+		}
+
+		$row->setState(RegistrySubscription::STATE_ENDED);
+		$row->setUpdatedAt(new DateTime());
+		$row = $this->subscriptionMapper->save(subscription: $row);
+
+		$this->eventDispatcher->dispatchTyped(new RegistrySubscriptionEndedEvent(
+			objectUuid: $uuid,
+			registry: (string)$row->getRegistry(),
+			identityValue: (string)$row->getIdentityValue(),
+		));
+
+		$this->auditTrailMapper->createAuditTrailEntry(
+			object: $object,
+			action: 'registry.subscription.ended',
+			context: ['registry' => $row->getRegistry()],
+		);
+
+		return $row;
+	}//end endSubscription()
+
+	/**
+	 * Apply an inbound registry update (`registry-subscriptions` REQ 3) to
+	 * every object actively subscribed to `$registry`/`$identityValue`.
+	 *
+	 * @param string $registry The registry id posting the update (`brp`, `kvk`, ...).
+	 * @param string $identityValue The identity value the update is for.
+	 * @param array<string, mixed> $properties The changed properties the registry is offering.
+	 * @param string $eventReference The registry's own event reference for this change.
+	 *
+	 * @return array{matched: int, applied: array<int, string>, rejected: array<int, array{objectUuid: string, properties: array<int, string>}>}
+	 *         `matched` is how many active subscriptions exist for this
+	 *         registry/identity — 0 means "no such subscription", which the
+	 *         controller answers 404, distinct from a match whose payload
+	 *         changed nothing (`matched` > 0, `applied` and `rejected` both
+	 *         empty), which is a 200 no-op per REQ 3 ("an unchanged payload
+	 *         announces nothing"). `applied` lists the object uuids that
+	 *         were updated; `rejected` names, per object, which supplied
+	 *         properties it does not own (that object's update was skipped
+	 *         entirely — a partial write of only the owned subset is never
+	 *         applied, so a caller cannot misread a rejected update as a
+	 *         smaller accepted one).
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
+	 */
+	public function applyInboundUpdate(
+		string $registry,
+		string $identityValue,
+		array $properties,
+		string $eventReference,
+	): array {
+		$rows = $this->subscriptionMapper->findActiveByIdentity(registry: $registry, identityValue: $identityValue);
+		$matched = count($rows);
+
+		$applied = [];
+		$rejected = [];
+
+		foreach ($rows as $row) {
+			$schema = $this->schemaMapper->find(id: (string)$row->getSchema());
+			$annotation = $this->annotationFor(schema: $schema);
+			if ($annotation === null) {
+				// The schema's annotation was removed after the subscription
+				// was requested. Treat exactly like an owned-property
+				// violation: refuse rather than silently apply an
+				// unauthorised write.
+				$rejected[] = ['objectUuid' => (string)$row->getObjectUuid(), 'properties' => array_keys($properties)];
+				continue;
+			}
+
+			$guardResult = $this->ownedPropertyGuard->check(owned: $annotation['owned'], supplied: $properties);
+			if ($guardResult['allowed'] === false) {
+				$rejected[] = ['objectUuid' => (string)$row->getObjectUuid(), 'properties' => $guardResult['rejected']];
+				continue;
+			}
+
+			if (count($properties) === 0) {
+				// An unchanged payload announces nothing (REQ 3): no write,
+				// no audit, and the row's freshness is left untouched.
+				continue;
+			}
+
+			try {
+				$updated = $this->objectService->saveObject(
+					object: $properties,
+					register: $row->getRegister(),
+					schema: $row->getSchema(),
+					uuid: $row->getObjectUuid(),
+				);
+			} catch (\Throwable $e) {
+				$this->logger->error(
+					'[OpenRegister.RegistrySubscriptionService] Inbound update failed to save for object '
+					. $row->getObjectUuid() . ': ' . $e->getMessage()
+				);
+				$rejected[] = ['objectUuid' => (string)$row->getObjectUuid(), 'properties' => array_keys($properties)];
+				continue;
+			}
+
+			$now = new DateTime();
+			$row->setLastUpdateAt($now);
+			$row->setLastUpdateSource($eventReference);
+			$row->setState(RegistrySubscription::STATE_ACTIVE);
+			$row->setUpdatedAt($now);
+			$this->subscriptionMapper->save(subscription: $row);
+
+			// A second, explicit audit row naming the REGISTRY as actor.
+			// saveObject()'s own audit trail already recorded this write
+			// with whichever Nextcloud account the connector's app password
+			// belongs to (the ordinary save path's session-derived actor);
+			// this row is the one `registry-subscriptions` REQ 3 asks for —
+			// "the audit entry names registry `brp` as actor" — independent
+			// of which account backs the connector's credential.
+			$this->auditTrailMapper->createAuditTrailEntry(
+				object: $updated,
+				action: 'registry.update',
+				context: ['registry' => $registry, 'eventReference' => $eventReference, 'properties' => array_keys($properties)],
+				actorId: 'registry:' . $registry,
+				actorName: 'Registry (' . $registry . ')',
+			);
+
+			$applied[] = (string)$row->getObjectUuid();
+		}//end foreach
+
+		return ['matched' => $matched, 'applied' => $applied, 'rejected' => $rejected];
+	}//end applyInboundUpdate()
+
+	/**
+	 * The `@self.registry` render mirror for one object, or null when it has
+	 * no subscription row.
+	 *
+	 * @param string $objectUuid The object's uuid.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public function stateFor(string $objectUuid): ?array {
+		$row = $this->subscriptionMapper->findForObject(objectUuid: $objectUuid);
+		if ($row === null) {
+			return null;
+		}
+
+		return $row->toSelfMirror();
+	}//end stateFor()
+
+	/**
+	 * Batch form of {@see stateFor()} for the render-mirror choke point,
+	 * avoiding one query per listed row.
+	 *
+	 * @param array<int, string> $objectUuids The object uuids to look up.
+	 *
+	 * @return array<string, array<string, mixed>> Mirrors, keyed by object uuid.
+	 */
+	public function statesFor(array $objectUuids): array {
+		$rows = $this->subscriptionMapper->findForObjects(objectUuids: $objectUuids);
+
+		$states = [];
+		foreach ($rows as $uuid => $row) {
+			$states[$uuid] = $row->toSelfMirror();
+		}
+
+		return $states;
+	}//end statesFor()
+}//end class

--- a/lib/Service/Registry/RegistrySubscriptionService.php
+++ b/lib/Service/Registry/RegistrySubscriptionService.php
@@ -72,6 +72,8 @@ class RegistrySubscriptionService {
 	 * @param Schema $schema The schema to read.
 	 *
 	 * @return array{registry: string, identity: string, owned: array<int, string>}|null
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-a-schema-declares-which-registry-owns-which-properties
 	 */
 	public function annotationFor(Schema $schema): ?array {
 		$configuration = ($schema->getConfiguration() ?? []);
@@ -283,6 +285,8 @@ class RegistrySubscriptionService {
 	 * @param string $objectUuid The object's uuid.
 	 *
 	 * @return array<string, mixed>|null
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
 	 */
 	public function stateFor(string $objectUuid): ?array {
 		$row = $this->subscriptionMapper->findForObject(objectUuid: $objectUuid);
@@ -300,6 +304,8 @@ class RegistrySubscriptionService {
 	 * @param array<int, string> $objectUuids The object uuids to look up.
 	 *
 	 * @return array<string, array<string, mixed>> Mirrors, keyed by object uuid.
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-object-carries-a-subscription-state-a-user-can-request-or-end
 	 */
 	public function statesFor(array $objectUuids): array {
 		$rows = $this->subscriptionMapper->findForObjects(objectUuids: $objectUuids);

--- a/lib/Service/Registry/RegistryUpdateTargetGuard.php
+++ b/lib/Service/Registry/RegistryUpdateTargetGuard.php
@@ -61,6 +61,8 @@ class RegistryUpdateTargetGuard {
 	 * @param array<string, mixed> $properties The inbound update's supplied properties.
 	 *
 	 * @return array{allowed: bool, rejected: array<int, string>}
+	 *
+	 * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
 	 */
 	public function evaluate(RegistrySubscription $row, array $properties): array {
 		try {

--- a/lib/Service/Registry/RegistryUpdateTargetGuard.php
+++ b/lib/Service/Registry/RegistryUpdateTargetGuard.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * OpenRegister RegistryUpdateTargetGuard
+ *
+ * Resolves one `RegistrySubscription` row's schema and decides whether an
+ * inbound update's properties may be applied to it. Extracted out of
+ * {@see RegistrySubscriptionService} to keep that service's coupling under
+ * this repo's PHPMD threshold: bundling "fetch the schema" and "check the
+ * properties against it" behind one collaborator removes two direct
+ * dependencies (`SchemaMapper`, `RegistryOwnedPropertyGuard`) for one.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Registry
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Registry;
+
+use OCA\OpenRegister\Db\RegistrySubscription;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use Throwable;
+
+/**
+ * Decides whether an inbound update's properties may be applied to one
+ * subscribed object.
+ *
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
+ */
+class RegistryUpdateTargetGuard {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SchemaMapper $schemaMapper Resolves the row's schema.
+	 * @param RegistryOwnedPropertyGuard $ownedPropertyGuard The pure owned-vs-supplied decision.
+	 */
+	public function __construct(
+		private readonly SchemaMapper $schemaMapper,
+		private readonly RegistryOwnedPropertyGuard $ownedPropertyGuard,
+	) {
+	}//end __construct()
+
+	/**
+	 * Evaluate one subscription row against a supplied property set.
+	 *
+	 * @param RegistrySubscription $row The subscription row to check.
+	 * @param array<string, mixed> $properties The inbound update's supplied properties.
+	 *
+	 * @return array{allowed: bool, rejected: array<int, string>}
+	 */
+	public function evaluate(RegistrySubscription $row, array $properties): array {
+		try {
+			$schema = $this->schemaMapper->find(id: (string)$row->getSchema());
+		} catch (Throwable) {
+			// The row's schema no longer resolves (deleted since the
+			// subscription was requested). Refuse rather than apply an
+			// update against a schema nobody can confirm still owns these
+			// properties.
+			return ['allowed' => false, 'rejected' => array_keys($properties)];
+		}
+
+		$owned = $this->ownedPropertiesOf(schema: $schema);
+		if ($owned === null) {
+			// The `x-openregister-registry` annotation was removed after the
+			// subscription was requested. Same reasoning as above: refuse.
+			return ['allowed' => false, 'rejected' => array_keys($properties)];
+		}
+
+		return $this->ownedPropertyGuard->check(owned: $owned, supplied: $properties);
+	}//end evaluate()
+
+	/**
+	 * Read the `owned` list off a schema's `x-openregister-registry`
+	 * annotation, or null when the schema does not declare one.
+	 *
+	 * Deliberately duplicates the small array-read
+	 * {@see RegistrySubscriptionService::annotationFor()} also performs,
+	 * rather than sharing it through a new dependency — the whole point of
+	 * this class existing is keeping that service's coupling count down.
+	 *
+	 * @param Schema $schema The schema to read.
+	 *
+	 * @return array<int, string>|null
+	 */
+	private function ownedPropertiesOf(Schema $schema): ?array {
+		$configuration = ($schema->getConfiguration() ?? []);
+		$annotation = ($configuration['x-openregister-registry'] ?? null);
+		if (is_array($annotation) === false) {
+			return null;
+		}
+
+		$owned = $annotation['owned'] ?? [];
+		if (is_array($owned) === false) {
+			return [];
+		}
+
+		return array_values(array_map('strval', $owned));
+	}//end ownedPropertiesOf()
+}//end class

--- a/openspec/changes/registry-subscriptions/design.md
+++ b/openspec/changes/registry-subscriptions/design.md
@@ -34,3 +34,44 @@ the object query, so a data steward lists stale subscribed persons.
 
 Code, in OpenRegister. Consuming apps add the annotation to their schema
 JSON, which is config; integriq ships the connector.
+
+## Implementation addendum, 2026-09-11
+
+Three decisions this proposal left to implementation time, recorded here
+rather than left implicit:
+
+- **D-2's "resolve the object by identity" mechanism.** The state table
+  (`openregister_registry_subs`) stores `identity_value` per row, captured
+  at request time from the object's own identity property. The inbound
+  endpoint looks rows up by `(registry, identity_value)`, filtered to
+  `active`. This is deliberately NOT unique on `(registry, identity_value)`:
+  two different objects — in different registers, e.g. two apps each
+  keeping their own `person` schema — may legitimately track the same
+  real-world BSN or KvK number, and a registry push updates every matching
+  active row, not just one. `applyInboundUpdate()` therefore returns
+  `{matched, applied, rejected}` rather than a single result, so a caller
+  (and the endpoint) can tell "no such subscription" (`matched === 0`, a
+  404) apart from "matched, but this payload changed nothing" (`matched`
+  > 0, both `applied` and `rejected` empty, REQ 3's "an unchanged payload
+  announces nothing" — a 200 no-op, not a 404).
+- **D-3's "audited with the registry as actor."** `ObjectService::saveObject()`
+  (the ordinary save path) audits with whichever Nextcloud account the
+  connector's app password belongs to — it has no actor-override parameter,
+  and widening that signature was out of scope for this change. Instead,
+  `applyInboundUpdate()` writes a SECOND, explicit audit row via
+  `AuditTrailMapper::createAuditTrailEntry()`, extended with optional
+  `$actorId`/`$actorName` parameters (both default `null`, so every
+  existing caller is unaffected) naming `registry:{id}` as the actor. Two
+  rows for one write is an acceptable and legible cost: one row is "who
+  authenticated the call", the other is "on whose authority the data
+  changed" — the second is what REQ 3's scenario actually asks a reviewer
+  to find.
+- **D-4's query lenses are DEFERRED**, not shipped. Wiring `_registry[state]`
+  / `_registry[updatedBefore]` means adding a new `EXISTS` join against
+  `openregister_registry_subs` inside `MagicSearchHandler::applyAccessControlFilters()`
+  — the same hot, per-request query-assembly path `MagicRbacHandler::applyRbacFilters()`
+  already extends for RBAC. That is not a change to make without a live
+  database to verify the generated SQL against, and it is not what
+  dossiq's `contacts-domain` task 4.3 is blocked on (that needs the
+  annotation + state + inbound endpoint, not a list-query filter). See
+  `tasks.md` 3.1.

--- a/openspec/changes/registry-subscriptions/tasks.md
+++ b/openspec/changes/registry-subscriptions/tasks.md
@@ -2,22 +2,83 @@
 
 ## 1. Declaration and state
 
-- [ ] 1.1 Validate `x-openregister-registry` at schema save.
-- [ ] 1.2 Subscription state table and `@self.registry` marker.
+- [x] 1.1 Validate `x-openregister-registry` at schema save.
+      `RegistryAnnotationValidator` (`lib/Service/Registry/`), wired as a
+      BLOCKING check (unlike most `x-openregister-*` dialects, which only
+      warn) in `SchemaMapper::validateRegistryAnnotation()`. Added to
+      `Schema::ANNOTATION_VOCABULARY`, or `setConfiguration()` silently
+      drops the key on save — see the vocabulary's own comment history for
+      why that check exists.
+- [x] 1.2 Subscription state table and `@self.registry` marker.
+      Table `openregister_registry_subs`
+      (`lib/Migration/Version1Date20260911170000.php`), entity/mapper
+      `RegistrySubscription`/`RegistrySubscriptionMapper` (`lib/Db/`).
+      `@self.registry` materialised via `ObjectEntity::$registryState` +
+      `RenderObject::renderEntity()`, the same "materialise unconditionally
+      at the render boundary" pattern as `@self.translationCompleteness`
+      and `@self._retention` — looked up only when the schema actually
+      declares the annotation, so the common case costs no extra query.
 
 ## 2. Endpoints and events
 
-- [ ] 2.1 Request and end subscription endpoints, dispatching the events.
-- [ ] 2.2 Inbound update endpoint applying owned properties only, audited
+- [x] 2.1 Request and end subscription endpoints, dispatching the events.
+      `RegistrySubscriptionController::subscribe()`/`unsubscribe()`
+      (`POST`/`DELETE` `/api/objects/{register}/{schema}/{id}/registry-subscription`),
+      per-object `update` guard via `PermissionHandler::hasPermission()`.
+      Dispatches `RegistrySubscriptionRequestedEvent` /
+      `RegistrySubscriptionEndedEvent` (the latter added beyond the
+      original design — REQ 2 says "each" action dispatches an event, and
+      the spec's own scenario only illustrated the request half).
+- [x] 2.2 Inbound update endpoint applying owned properties only, audited
       with the registry as actor.
+      `RegistryUpdatesController::update()` (`POST /api/registry/{registry}/updates`),
+      `RegistrySubscriptionService::applyInboundUpdate()`. The owned-vs-
+      supplied decision is a pure class, `RegistryOwnedPropertyGuard`, so
+      it is unit-testable without a database. The "registry as actor" audit
+      requirement is met with a SECOND, explicit audit row
+      (`AuditTrailMapper::createAuditTrailEntry()`, extended with optional
+      `$actorId`/`$actorName` params, backward compatible) alongside
+      whatever `ObjectService::saveObject()`'s own ordinary-save-path audit
+      records for the connector's actual Nextcloud app-password account —
+      see design.md addendum below for why.
 
 ## 3. Query
 
 - [ ] 3.1 `_registry[state]` and `_registry[updatedBefore]` lenses.
+      DEFERRED, deliberately, not silently dropped. The injection point
+      exists (`MagicSearchHandler::applyAccessControlFilters()`, beside
+      `MagicRbacHandler::applyRbacFilters()` — both build `WHERE`/`EXISTS`
+      SQL against the schema's magic table), but wiring a new EXISTS join
+      against `openregister_registry_subs` into that hot, heavily-shared
+      query path without a live database to verify the generated SQL
+      against is not a change to make blind. This is also not what blocks
+      dossiq `contacts-domain` task 4.3 (that needs the annotation + state
+      + inbound endpoint above, not a list-query filter). Left for a
+      follow-up change with DB-backed integration tests.
 
 ## 4. Tests
 
-- [ ] 4.1 Unit tests for validation, the owned-property guard and lenses.
+- [x] 4.1 Unit tests for validation and the owned-property guard: real,
+      run, and mutation-checked in this session —
+      `tests/Unit/Service/Registry/RegistryAnnotationValidatorTest.php` (9
+      cases) and `RegistryOwnedPropertyGuardTest.php` (5 cases), both pure
+      PHP with no Nextcloud/DB dependency. Lenses excluded (3.1 deferred).
+      `tests/Unit/Service/Registry/RegistrySubscriptionServiceTest.php` (10
+      cases, mocked collaborators, standard convention for this codebase's
+      Service-layer tests) is WRITTEN but could not be EXECUTED in the
+      sandbox this change was authored in: it needs `nextcloud/ocp`'s
+      classes loaded from a real Nextcloud boot (`../../lib/base.php`),
+      which this checkout's location does not provide — confirmed as a
+      pre-existing, unmodified-code limitation by running an existing test
+      in this repo (`LockHandlerRunLockTest`) and observing the identical
+      `Class "OCP\AppFramework\Db\QBMapper" not found` failure. Expected to
+      run green under `code-quality.yml`, which boots inside a real
+      Nextcloud container.
 - [ ] 4.2 `tests/e2e/api-direct/registry-subscriptions.spec.ts`: request a
       subscription, post an inbound update, read the changed property and
-      the audit actor.
+      the audit actor. NOT written in this change — it needs a running
+      instance with a schema carrying `x-openregister-registry` and a way
+      to authenticate as a "connector", neither of which exists in fixture
+      form yet. Left for the change that adds the annotation to a real
+      consumer schema (dossiq's `brpPerson`/`kvkCompany`, tracked in
+      dossiq's `contacts-domain` task 4.3).

--- a/tests/Unit/Service/Registry/RegistryAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Registry/RegistryAnnotationValidatorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Registry;
+
+use OCA\OpenRegister\Service\Registry\RegistryAnnotationValidator;
+use PHPUnit\Framework\TestCase;
+
+class RegistryAnnotationValidatorTest extends TestCase {
+	private RegistryAnnotationValidator $v;
+
+	protected function setUp(): void {
+		$this->v = new RegistryAnnotationValidator();
+	}
+
+	public function testNoAnnotationIsValid(): void {
+		$this->assertSame([], $this->v->validate(['properties' => []]));
+	}
+
+	public function testValidAnnotation(): void {
+		$errors = $this->v->validate([
+			'properties' => [
+				'bsn' => ['type' => 'string'],
+				'givenNames' => ['type' => 'string'],
+				'birthDate' => ['type' => 'string', 'format' => 'date'],
+			],
+			'x-openregister-registry' => [
+				'registry' => 'brp',
+				'identity' => 'bsn',
+				'owned' => ['givenNames', 'birthDate'],
+			],
+		]);
+		$this->assertSame([], $errors);
+	}
+
+	public function testNonArrayAnnotationIsRejected(): void {
+		$errors = $this->v->validate(['x-openregister-registry' => 'brp']);
+		$this->assertSame('registry-malformed', $errors[0]['code']);
+	}
+
+	public function testMissingRegistryIdIsRejected(): void {
+		$errors = $this->v->validate([
+			'properties' => ['bsn' => ['type' => 'string']],
+			'x-openregister-registry' => ['identity' => 'bsn', 'owned' => ['bsn']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('registry-id-missing', $codes);
+	}
+
+	public function testMissingIdentityIsRejected(): void {
+		$errors = $this->v->validate([
+			'properties' => ['bsn' => ['type' => 'string']],
+			'x-openregister-registry' => ['registry' => 'brp', 'owned' => ['bsn']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('registry-identity-missing', $codes);
+	}
+
+	public function testIdentityNotDeclaredInSchemaIsRejected(): void {
+		$errors = $this->v->validate([
+			'properties' => ['givenNames' => ['type' => 'string']],
+			'x-openregister-registry' => [
+				'registry' => 'brp',
+				'identity' => 'bsn',
+				'owned' => ['givenNames'],
+			],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('registry-identity-undeclared', $codes);
+	}
+
+	public function testOwnedPropertyNotDeclaredInSchemaIsRejected(): void {
+		$errors = $this->v->validate([
+			'properties' => ['bsn' => ['type' => 'string']],
+			'x-openregister-registry' => [
+				'registry' => 'brp',
+				'identity' => 'bsn',
+				'owned' => ['birthDate'],
+			],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('registry-owned-undeclared', $codes);
+	}
+
+	public function testEmptyOwnedIsRejected(): void {
+		$errors = $this->v->validate([
+			'properties' => ['bsn' => ['type' => 'string']],
+			'x-openregister-registry' => [
+				'registry' => 'brp',
+				'identity' => 'bsn',
+				'owned' => [],
+			],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('registry-owned-missing', $codes);
+	}
+
+	public function testNonStringOwnedEntryIsRejected(): void {
+		$errors = $this->v->validate([
+			'properties' => ['bsn' => ['type' => 'string']],
+			'x-openregister-registry' => [
+				'registry' => 'brp',
+				'identity' => 'bsn',
+				'owned' => [123],
+			],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('registry-owned-malformed', $codes);
+	}
+}

--- a/tests/Unit/Service/Registry/RegistryOwnedPropertyGuardTest.php
+++ b/tests/Unit/Service/Registry/RegistryOwnedPropertyGuardTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Registry;
+
+use OCA\OpenRegister\Service\Registry\RegistryOwnedPropertyGuard;
+use PHPUnit\Framework\TestCase;
+
+class RegistryOwnedPropertyGuardTest extends TestCase {
+	private RegistryOwnedPropertyGuard $guard;
+
+	protected function setUp(): void {
+		$this->guard = new RegistryOwnedPropertyGuard();
+	}
+
+	public function testAllSuppliedPropertiesOwnedIsAllowed(): void {
+		$result = $this->guard->check(
+			owned: ['address', 'givenNames'],
+			supplied: ['address' => 'Dam 1'],
+		);
+		$this->assertTrue($result['allowed']);
+		$this->assertSame([], $result['rejected']);
+	}
+
+	public function testASuppliedPropertyOutsideOwnedIsRejected(): void {
+		$result = $this->guard->check(
+			owned: ['address'],
+			supplied: ['address' => 'Dam 1', 'notes' => 'secret'],
+		);
+		$this->assertFalse($result['allowed']);
+		$this->assertSame(['notes'], $result['rejected']);
+	}
+
+	public function testEveryOffendingKeyIsNamedNotJustTheFirst(): void {
+		$result = $this->guard->check(
+			owned: ['address'],
+			supplied: ['notes' => 'a', 'internalFlag' => true],
+		);
+		$this->assertFalse($result['allowed']);
+		$this->assertSame(['notes', 'internalFlag'], $result['rejected']);
+	}
+
+	public function testEmptySuppliedIsAllowed(): void {
+		$result = $this->guard->check(owned: ['address'], supplied: []);
+		$this->assertTrue($result['allowed']);
+	}
+
+	public function testEmptyOwnedRejectsAnySuppliedProperty(): void {
+		$result = $this->guard->check(owned: [], supplied: ['address' => 'Dam 1']);
+		$this->assertFalse($result['allowed']);
+		$this->assertSame(['address'], $result['rejected']);
+	}
+}

--- a/tests/Unit/Service/Registry/RegistrySubscriptionNotifierTest.php
+++ b/tests/Unit/Service/Registry/RegistrySubscriptionNotifierTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Registry;
+
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Event\RegistrySubscriptionEndedEvent;
+use OCA\OpenRegister\Event\RegistrySubscriptionRequestedEvent;
+use OCA\OpenRegister\Service\Registry\RegistrySubscriptionNotifier;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
+ */
+class RegistrySubscriptionNotifierTest extends TestCase {
+	private RegistrySubscriptionNotifier $notifier;
+	private IEventDispatcher&MockObject $eventDispatcher;
+	private AuditTrailMapper&MockObject $auditTrailMapper;
+
+	protected function setUp(): void {
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+		$this->notifier = new RegistrySubscriptionNotifier($this->eventDispatcher, $this->auditTrailMapper);
+	}
+
+	private function personObject(string $uuid = 'obj-uuid-1'): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+
+		return $object;
+	}
+
+	public function testRequestedDispatchesEventWithIdentityValue(): void {
+		$dispatched = null;
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->callback(function ($event) use (&$dispatched) {
+				$dispatched = $event;
+				return $event instanceof RegistrySubscriptionRequestedEvent;
+			}));
+
+		$this->notifier->requested($this->personObject(), 'dossiq', 'brpPerson', 'brp', '999990019');
+
+		$this->assertInstanceOf(RegistrySubscriptionRequestedEvent::class, $dispatched);
+		$this->assertSame('999990019', $dispatched->getIdentityValue());
+		$this->assertSame('brp', $dispatched->getRegistry());
+	}
+
+	public function testRequestedWritesAnAuditEntry(): void {
+		$this->auditTrailMapper->expects($this->once())
+			->method('createAuditTrailEntry')
+			->with(
+				$this->anything(),
+				'registry.subscription.requested',
+				$this->anything(),
+			);
+
+		$this->notifier->requested($this->personObject(), 'dossiq', 'brpPerson', 'brp', '999990019');
+	}
+
+	public function testEndedDispatchesEvent(): void {
+		$dispatched = null;
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->callback(function ($event) use (&$dispatched) {
+				$dispatched = $event;
+				return $event instanceof RegistrySubscriptionEndedEvent;
+			}));
+
+		$this->notifier->ended($this->personObject(), 'brp', '999990019');
+
+		$this->assertInstanceOf(RegistrySubscriptionEndedEvent::class, $dispatched);
+		$this->assertSame('brp', $dispatched->getRegistry());
+	}
+
+	public function testAuditInboundUpdateNamesTheRegistryAsActor(): void {
+		$object = $this->personObject();
+
+		$this->auditTrailMapper->expects($this->once())
+			->method('createAuditTrailEntry')
+			->with(
+				$object,
+				'registry.update',
+				$this->anything(),
+				'registry:brp',
+				$this->anything(),
+			);
+
+		$this->notifier->auditInboundUpdate($object, 'brp', 'evt-1', ['address']);
+	}
+}

--- a/tests/Unit/Service/Registry/RegistrySubscriptionServiceTest.php
+++ b/tests/Unit/Service/Registry/RegistrySubscriptionServiceTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Registry;
+
+use InvalidArgumentException;
+use OCA\OpenRegister\Db\AuditTrailMapper;
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegistrySubscription;
+use OCA\OpenRegister\Db\RegistrySubscriptionMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\RegistrySubscriptionRequestedEvent;
+use OCA\OpenRegister\Service\ObjectService;
+use OCA\OpenRegister\Service\Registry\RegistryOwnedPropertyGuard;
+use OCA\OpenRegister\Service\Registry\RegistrySubscriptionService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
+ */
+class RegistrySubscriptionServiceTest extends TestCase {
+	private RegistrySubscriptionService $service;
+	private RegistrySubscriptionMapper&MockObject $subscriptionMapper;
+	private SchemaMapper&MockObject $schemaMapper;
+	private ObjectService&MockObject $objectService;
+	private AuditTrailMapper&MockObject $auditTrailMapper;
+	private IEventDispatcher&MockObject $eventDispatcher;
+
+	protected function setUp(): void {
+		$this->subscriptionMapper = $this->createMock(RegistrySubscriptionMapper::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->objectService = $this->createMock(ObjectService::class);
+		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+
+		$this->service = new RegistrySubscriptionService(
+			$this->subscriptionMapper,
+			$this->schemaMapper,
+			$this->objectService,
+			$this->auditTrailMapper,
+			$this->eventDispatcher,
+			new RegistryOwnedPropertyGuard(),
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	private function brpSchema(): Schema {
+		$schema = new Schema();
+		$schema->setConfiguration([
+			'x-openregister-registry' => [
+				'registry' => 'brp',
+				'identity' => 'bsn',
+				'owned' => ['address', 'givenNames'],
+			],
+		]);
+
+		return $schema;
+	}
+
+	private function personObject(string $uuid = 'obj-uuid-1', string $bsn = '999990019'): ObjectEntity {
+		$object = new ObjectEntity();
+		$object->setUuid($uuid);
+		$object->setRegister('dossiq');
+		$object->setSchema('brpPerson');
+		$object->setObject(['bsn' => $bsn, 'givenNames' => 'Stephan']);
+
+		return $object;
+	}
+
+	// ── requestSubscription ──
+
+	public function testRequestSubscriptionWithoutAnnotationIsRejected(): void {
+		$this->expectException(InvalidArgumentException::class);
+		$this->service->requestSubscription($this->personObject(), new Schema());
+	}
+
+	public function testRequestSubscriptionWithoutIdentityValueIsRejected(): void {
+		$object = $this->personObject(bsn: '');
+		$this->expectException(InvalidArgumentException::class);
+		$this->service->requestSubscription($object, $this->brpSchema());
+	}
+
+	public function testRequestSubscriptionDispatchesEventWithIdentityValue(): void {
+		$this->subscriptionMapper->method('findForObject')->willReturn(null);
+		$this->subscriptionMapper->method('save')->willReturnArgument(0);
+
+		$dispatched = null;
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->callback(function ($event) use (&$dispatched) {
+				$dispatched = $event;
+				return $event instanceof RegistrySubscriptionRequestedEvent;
+			}));
+
+		$row = $this->service->requestSubscription($this->personObject(), $this->brpSchema());
+
+		$this->assertSame(RegistrySubscription::STATE_REQUESTED, $row->getState());
+		$this->assertSame('999990019', $row->getIdentityValue());
+		$this->assertSame('brp', $row->getRegistry());
+		$this->assertInstanceOf(RegistrySubscriptionRequestedEvent::class, $dispatched);
+		$this->assertSame('999990019', $dispatched->getIdentityValue());
+	}
+
+	public function testRequestSubscriptionWritesAnAuditEntry(): void {
+		$this->subscriptionMapper->method('findForObject')->willReturn(null);
+		$this->subscriptionMapper->method('save')->willReturnArgument(0);
+
+		$this->auditTrailMapper->expects($this->once())
+			->method('createAuditTrailEntry')
+			->with(
+				$this->anything(),
+				'registry.subscription.requested',
+				$this->anything(),
+			);
+
+		$this->service->requestSubscription($this->personObject(), $this->brpSchema());
+	}
+
+	// ── endSubscription ──
+
+	public function testEndSubscriptionWithNoExistingRowThrows(): void {
+		$this->subscriptionMapper->method('findForObject')->willReturn(null);
+		$this->expectException(DoesNotExistException::class);
+		$this->service->endSubscription($this->personObject());
+	}
+
+	public function testEndSubscriptionSetsStateEnded(): void {
+		$row = new RegistrySubscription();
+		$row->setRegistry('brp');
+		$row->setIdentityValue('999990019');
+		$this->subscriptionMapper->method('findForObject')->willReturn($row);
+		$this->subscriptionMapper->method('save')->willReturnArgument(0);
+
+		$result = $this->service->endSubscription($this->personObject());
+
+		$this->assertSame(RegistrySubscription::STATE_ENDED, $result->getState());
+	}
+
+	// ── applyInboundUpdate ──
+
+	public function testApplyInboundUpdateWithNoMatchesAppliesNothing(): void {
+		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([]);
+
+		$result = $this->service->applyInboundUpdate('brp', '999990019', ['address' => 'Dam 1'], 'evt-1');
+
+		$this->assertSame(0, $result['matched']);
+		$this->assertSame([], $result['applied']);
+		$this->assertSame([], $result['rejected']);
+	}
+
+	public function testApplyInboundUpdateAppliesOwnedPropertiesThroughSaveObject(): void {
+		$row = new RegistrySubscription();
+		$row->setObjectUuid('obj-uuid-1');
+		$row->setRegister('dossiq');
+		$row->setSchema('brpPerson');
+		$row->setRegistry('brp');
+		$row->setIdentityValue('999990019');
+		$row->setState(RegistrySubscription::STATE_ACTIVE);
+
+		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([$row]);
+		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+
+		$saved = $this->personObject();
+		$this->objectService->expects($this->once())
+			->method('saveObject')
+			->with(
+				$this->equalTo(['address' => 'Dam 1']),
+				register: 'dossiq',
+				schema: 'brpPerson',
+				uuid: 'obj-uuid-1',
+			)
+			->willReturn($saved);
+
+		$this->auditTrailMapper->expects($this->once())
+			->method('createAuditTrailEntry')
+			->with(
+				$saved,
+				'registry.update',
+				$this->anything(),
+				'registry:brp',
+				$this->anything(),
+			);
+
+		$result = $this->service->applyInboundUpdate('brp', '999990019', ['address' => 'Dam 1'], 'evt-1');
+
+		$this->assertSame(['obj-uuid-1'], $result['applied']);
+		$this->assertSame([], $result['rejected']);
+	}
+
+	public function testApplyInboundUpdateRejectsAPropertyOutsideOwned(): void {
+		$row = new RegistrySubscription();
+		$row->setObjectUuid('obj-uuid-1');
+		$row->setRegister('dossiq');
+		$row->setSchema('brpPerson');
+		$row->setRegistry('brp');
+		$row->setIdentityValue('999990019');
+		$row->setState(RegistrySubscription::STATE_ACTIVE);
+
+		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([$row]);
+		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		$result = $this->service->applyInboundUpdate('brp', '999990019', ['notes' => 'secret'], 'evt-1');
+
+		$this->assertSame([], $result['applied']);
+		$this->assertCount(1, $result['rejected']);
+		$this->assertSame('obj-uuid-1', $result['rejected'][0]['objectUuid']);
+		$this->assertSame(['notes'], $result['rejected'][0]['properties']);
+	}
+
+	public function testApplyInboundUpdateWithEmptyPayloadAnnouncesNothing(): void {
+		$row = new RegistrySubscription();
+		$row->setObjectUuid('obj-uuid-1');
+		$row->setRegister('dossiq');
+		$row->setSchema('brpPerson');
+		$row->setRegistry('brp');
+		$row->setIdentityValue('999990019');
+		$row->setState(RegistrySubscription::STATE_ACTIVE);
+
+		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([$row]);
+		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+
+		$this->objectService->expects($this->never())->method('saveObject');
+		$this->auditTrailMapper->expects($this->never())->method('createAuditTrailEntry');
+
+		$result = $this->service->applyInboundUpdate('brp', '999990019', [], 'evt-1');
+
+		// matched=1 (a subscription DOES exist) but nothing to apply — the
+		// controller's 404-vs-200-noop distinction depends on telling this
+		// apart from the zero-matches case above.
+		$this->assertSame(1, $result['matched']);
+		$this->assertSame([], $result['applied']);
+		$this->assertSame([], $result['rejected']);
+	}
+}

--- a/tests/Unit/Service/Registry/RegistrySubscriptionServiceTest.php
+++ b/tests/Unit/Service/Registry/RegistrySubscriptionServiceTest.php
@@ -5,47 +5,47 @@ declare(strict_types=1);
 namespace Unit\Service\Registry;
 
 use InvalidArgumentException;
-use OCA\OpenRegister\Db\AuditTrailMapper;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Db\RegistrySubscription;
 use OCA\OpenRegister\Db\RegistrySubscriptionMapper;
 use OCA\OpenRegister\Db\Schema;
-use OCA\OpenRegister\Db\SchemaMapper;
-use OCA\OpenRegister\Event\RegistrySubscriptionRequestedEvent;
 use OCA\OpenRegister\Service\ObjectService;
-use OCA\OpenRegister\Service\Registry\RegistryOwnedPropertyGuard;
+use OCA\OpenRegister\Service\Registry\RegistrySubscriptionNotifier;
 use OCA\OpenRegister\Service\Registry\RegistrySubscriptionService;
+use OCA\OpenRegister\Service\Registry\RegistryUpdateTargetGuard;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
+ * Orchestration tests for RegistrySubscriptionService. The event/audit
+ * dispatch behavior lives in RegistrySubscriptionNotifierTest, and the
+ * owned-property decision behavior lives in RegistryUpdateTargetGuardTest —
+ * both are mocked here as opaque collaborators so this file only asserts
+ * what THIS class is responsible for: reading the annotation, building and
+ * persisting the state row, and deciding matched/applied/rejected.
+ *
  * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md
  */
 class RegistrySubscriptionServiceTest extends TestCase {
 	private RegistrySubscriptionService $service;
 	private RegistrySubscriptionMapper&MockObject $subscriptionMapper;
-	private SchemaMapper&MockObject $schemaMapper;
 	private ObjectService&MockObject $objectService;
-	private AuditTrailMapper&MockObject $auditTrailMapper;
-	private IEventDispatcher&MockObject $eventDispatcher;
+	private RegistrySubscriptionNotifier&MockObject $notifier;
+	private RegistryUpdateTargetGuard&MockObject $updateTargetGuard;
 
 	protected function setUp(): void {
 		$this->subscriptionMapper = $this->createMock(RegistrySubscriptionMapper::class);
-		$this->schemaMapper = $this->createMock(SchemaMapper::class);
 		$this->objectService = $this->createMock(ObjectService::class);
-		$this->auditTrailMapper = $this->createMock(AuditTrailMapper::class);
-		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->notifier = $this->createMock(RegistrySubscriptionNotifier::class);
+		$this->updateTargetGuard = $this->createMock(RegistryUpdateTargetGuard::class);
 
 		$this->service = new RegistrySubscriptionService(
 			$this->subscriptionMapper,
-			$this->schemaMapper,
 			$this->objectService,
-			$this->auditTrailMapper,
-			$this->eventDispatcher,
-			new RegistryOwnedPropertyGuard(),
+			$this->notifier,
+			$this->updateTargetGuard,
 			$this->createMock(LoggerInterface::class),
 		);
 	}
@@ -73,6 +73,20 @@ class RegistrySubscriptionServiceTest extends TestCase {
 		return $object;
 	}
 
+	// ── annotationFor ──
+
+	public function testAnnotationForReturnsNullWhenSchemaHasNoAnnotation(): void {
+		$this->assertNull($this->service->annotationFor(new Schema()));
+	}
+
+	public function testAnnotationForReadsTheDeclaredFields(): void {
+		$annotation = $this->service->annotationFor($this->brpSchema());
+
+		$this->assertSame('brp', $annotation['registry']);
+		$this->assertSame('bsn', $annotation['identity']);
+		$this->assertSame(['address', 'givenNames'], $annotation['owned']);
+	}
+
 	// ── requestSubscription ──
 
 	public function testRequestSubscriptionWithoutAnnotationIsRejected(): void {
@@ -86,40 +100,37 @@ class RegistrySubscriptionServiceTest extends TestCase {
 		$this->service->requestSubscription($object, $this->brpSchema());
 	}
 
-	public function testRequestSubscriptionDispatchesEventWithIdentityValue(): void {
+	public function testRequestSubscriptionPersistsARequestedRowAndNotifies(): void {
 		$this->subscriptionMapper->method('findForObject')->willReturn(null);
 		$this->subscriptionMapper->method('save')->willReturnArgument(0);
 
-		$dispatched = null;
-		$this->eventDispatcher->expects($this->once())
-			->method('dispatchTyped')
-			->with($this->callback(function ($event) use (&$dispatched) {
-				$dispatched = $event;
-				return $event instanceof RegistrySubscriptionRequestedEvent;
-			}));
+		$this->notifier->expects($this->once())
+			->method('requested')
+			->with(
+				$this->anything(),
+				'dossiq',
+				'brpPerson',
+				'brp',
+				'999990019',
+			);
 
 		$row = $this->service->requestSubscription($this->personObject(), $this->brpSchema());
 
 		$this->assertSame(RegistrySubscription::STATE_REQUESTED, $row->getState());
 		$this->assertSame('999990019', $row->getIdentityValue());
 		$this->assertSame('brp', $row->getRegistry());
-		$this->assertInstanceOf(RegistrySubscriptionRequestedEvent::class, $dispatched);
-		$this->assertSame('999990019', $dispatched->getIdentityValue());
 	}
 
-	public function testRequestSubscriptionWritesAnAuditEntry(): void {
-		$this->subscriptionMapper->method('findForObject')->willReturn(null);
-		$this->subscriptionMapper->method('save')->willReturnArgument(0);
+	public function testRequestSubscriptionReusesAnExistingRowRatherThanDuplicating(): void {
+		$existing = new RegistrySubscription();
+		$existing->setId(42);
+		$existing->setObjectUuid('obj-uuid-1');
+		$this->subscriptionMapper->method('findForObject')->willReturn($existing);
+		$this->subscriptionMapper->expects($this->once())->method('save')->willReturnArgument(0);
 
-		$this->auditTrailMapper->expects($this->once())
-			->method('createAuditTrailEntry')
-			->with(
-				$this->anything(),
-				'registry.subscription.requested',
-				$this->anything(),
-			);
+		$row = $this->service->requestSubscription($this->personObject(), $this->brpSchema());
 
-		$this->service->requestSubscription($this->personObject(), $this->brpSchema());
+		$this->assertSame(42, $row->getId());
 	}
 
 	// ── endSubscription ──
@@ -130,12 +141,14 @@ class RegistrySubscriptionServiceTest extends TestCase {
 		$this->service->endSubscription($this->personObject());
 	}
 
-	public function testEndSubscriptionSetsStateEnded(): void {
+	public function testEndSubscriptionSetsStateEndedAndNotifies(): void {
 		$row = new RegistrySubscription();
 		$row->setRegistry('brp');
 		$row->setIdentityValue('999990019');
 		$this->subscriptionMapper->method('findForObject')->willReturn($row);
 		$this->subscriptionMapper->method('save')->willReturnArgument(0);
+
+		$this->notifier->expects($this->once())->method('ended')->with($this->anything(), 'brp', '999990019');
 
 		$result = $this->service->endSubscription($this->personObject());
 
@@ -146,6 +159,7 @@ class RegistrySubscriptionServiceTest extends TestCase {
 
 	public function testApplyInboundUpdateWithNoMatchesAppliesNothing(): void {
 		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([]);
+		$this->updateTargetGuard->expects($this->never())->method('evaluate');
 
 		$result = $this->service->applyInboundUpdate('brp', '999990019', ['address' => 'Dam 1'], 'evt-1');
 
@@ -164,7 +178,7 @@ class RegistrySubscriptionServiceTest extends TestCase {
 		$row->setState(RegistrySubscription::STATE_ACTIVE);
 
 		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([$row]);
-		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+		$this->updateTargetGuard->method('evaluate')->willReturn(['allowed' => true, 'rejected' => []]);
 
 		$saved = $this->personObject();
 		$this->objectService->expects($this->once())
@@ -177,15 +191,9 @@ class RegistrySubscriptionServiceTest extends TestCase {
 			)
 			->willReturn($saved);
 
-		$this->auditTrailMapper->expects($this->once())
-			->method('createAuditTrailEntry')
-			->with(
-				$saved,
-				'registry.update',
-				$this->anything(),
-				'registry:brp',
-				$this->anything(),
-			);
+		$this->notifier->expects($this->once())
+			->method('auditInboundUpdate')
+			->with($saved, 'brp', 'evt-1', ['address']);
 
 		$result = $this->service->applyInboundUpdate('brp', '999990019', ['address' => 'Dam 1'], 'evt-1');
 
@@ -203,7 +211,7 @@ class RegistrySubscriptionServiceTest extends TestCase {
 		$row->setState(RegistrySubscription::STATE_ACTIVE);
 
 		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([$row]);
-		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+		$this->updateTargetGuard->method('evaluate')->willReturn(['allowed' => false, 'rejected' => ['notes']]);
 
 		$this->objectService->expects($this->never())->method('saveObject');
 
@@ -225,10 +233,10 @@ class RegistrySubscriptionServiceTest extends TestCase {
 		$row->setState(RegistrySubscription::STATE_ACTIVE);
 
 		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([$row]);
-		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+		$this->updateTargetGuard->method('evaluate')->willReturn(['allowed' => true, 'rejected' => []]);
 
 		$this->objectService->expects($this->never())->method('saveObject');
-		$this->auditTrailMapper->expects($this->never())->method('createAuditTrailEntry');
+		$this->notifier->expects($this->never())->method('auditInboundUpdate');
 
 		$result = $this->service->applyInboundUpdate('brp', '999990019', [], 'evt-1');
 

--- a/tests/Unit/Service/Registry/RegistrySubscriptionServiceTest.php
+++ b/tests/Unit/Service/Registry/RegistrySubscriptionServiceTest.php
@@ -180,20 +180,33 @@ class RegistrySubscriptionServiceTest extends TestCase {
 		$this->subscriptionMapper->method('findActiveByIdentity')->willReturn([$row]);
 		$this->updateTargetGuard->method('evaluate')->willReturn(['allowed' => true, 'rejected' => []]);
 
+		// Argument correctness is checked inside these callbacks, reading
+		// PHP's own resolved positional values, rather than via with() —
+		// with() constraints declared with named-argument labels do not
+		// reliably bind to the mocked method's real parameter positions
+		// across PHPUnit versions, and a silent positional mismatch (this
+		// service calls both methods with named arguments) would make the
+		// mock fall through unmatched and this test would then be
+		// exercising nothing.
 		$saved = $this->personObject();
 		$this->objectService->expects($this->once())
 			->method('saveObject')
-			->with(
-				$this->equalTo(['address' => 'Dam 1']),
-				register: 'dossiq',
-				schema: 'brpPerson',
-				uuid: 'obj-uuid-1',
-			)
-			->willReturn($saved);
+			->willReturnCallback(function ($object, $extend = [], $register = null, $schema = null, $uuid = null) use ($saved) {
+				$this->assertSame(['address' => 'Dam 1'], $object);
+				$this->assertSame('dossiq', $register);
+				$this->assertSame('brpPerson', $schema);
+				$this->assertSame('obj-uuid-1', $uuid);
+				return $saved;
+			});
 
 		$this->notifier->expects($this->once())
 			->method('auditInboundUpdate')
-			->with($saved, 'brp', 'evt-1', ['address']);
+			->willReturnCallback(function ($object, $registry, $eventReference, $properties) use ($saved) {
+				$this->assertSame($saved, $object);
+				$this->assertSame('brp', $registry);
+				$this->assertSame('evt-1', $eventReference);
+				$this->assertSame(['address'], $properties);
+			});
 
 		$result = $this->service->applyInboundUpdate('brp', '999990019', ['address' => 'Dam 1'], 'evt-1');
 

--- a/tests/Unit/Service/Registry/RegistryUpdateTargetGuardTest.php
+++ b/tests/Unit/Service/Registry/RegistryUpdateTargetGuardTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Unit\Service\Registry;
+
+use OCA\OpenRegister\Db\RegistrySubscription;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Service\Registry\RegistryOwnedPropertyGuard;
+use OCA\OpenRegister\Service\Registry\RegistryUpdateTargetGuard;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @spec openspec/changes/registry-subscriptions/specs/registry-subscriptions/spec.md#requirement-an-inbound-registry-update-writes-owned-properties-only
+ */
+class RegistryUpdateTargetGuardTest extends TestCase {
+	private RegistryUpdateTargetGuard $guard;
+	private SchemaMapper&MockObject $schemaMapper;
+
+	protected function setUp(): void {
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->guard = new RegistryUpdateTargetGuard($this->schemaMapper, new RegistryOwnedPropertyGuard());
+	}
+
+	private function brpSchema(): Schema {
+		$schema = new Schema();
+		$schema->setConfiguration([
+			'x-openregister-registry' => [
+				'registry' => 'brp',
+				'identity' => 'bsn',
+				'owned' => ['address', 'givenNames'],
+			],
+		]);
+
+		return $schema;
+	}
+
+	private function row(): RegistrySubscription {
+		$row = new RegistrySubscription();
+		$row->setSchema('brpPerson');
+
+		return $row;
+	}
+
+	public function testAnOwnedPropertyIsAllowed(): void {
+		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+
+		$result = $this->guard->evaluate($this->row(), ['address' => 'Dam 1']);
+
+		$this->assertTrue($result['allowed']);
+	}
+
+	public function testAPropertyOutsideOwnedIsRejected(): void {
+		$this->schemaMapper->method('find')->willReturn($this->brpSchema());
+
+		$result = $this->guard->evaluate($this->row(), ['notes' => 'secret']);
+
+		$this->assertFalse($result['allowed']);
+		$this->assertSame(['notes'], $result['rejected']);
+	}
+
+	public function testASchemaWithoutTheAnnotationRejectsEverySuppliedProperty(): void {
+		$this->schemaMapper->method('find')->willReturn(new Schema());
+
+		$result = $this->guard->evaluate($this->row(), ['address' => 'Dam 1']);
+
+		$this->assertFalse($result['allowed']);
+		$this->assertSame(['address'], $result['rejected']);
+	}
+
+	public function testASchemaThatNoLongerResolvesRejectsEverySuppliedProperty(): void {
+		$this->schemaMapper->method('find')->willThrowException(new \Exception('gone'));
+
+		$result = $this->guard->evaluate($this->row(), ['address' => 'Dam 1']);
+
+		$this->assertFalse($result['allowed']);
+		$this->assertSame(['address'], $result['rejected']);
+	}
+}


### PR DESCRIPTION
Recreated PR: #3645 never received a pull_request-triggered Code Quality run across 3 pushes and a close/reopen (confirmed via the Actions API against each exact head SHA — zero such runs scheduled, not skipped). See #3645 for the original description and review history; this is the same branch, same commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)