### PR TITLE
refactor(magic-mapper): delete two stubs that answer nothing and nobody calls

### DIFF
--- a/lib/Db/MagicMapper.php
+++ b/lib/Db/MagicMapper.php
@@ -10714,30 +10714,4 @@ class MagicMapper extends AbstractObjectMapper {
 			'series' => [],
 		];
 	}//end getSizeDistributionChartData()
-
-	/**
-	 * Count objects across multiple schemas.
-	 *
-	 * @param array $schemaIds Array of schema IDs.
-	 *
-	 * @return int Total count of objects across the given schemas.
-	 */
-	public function countBySchemas(array $schemaIds): int {
-		return 0;
-	}//end countBySchemas()
-
-	/**
-	 * Find objects across multiple schemas.
-	 *
-	 * @param array $schemaIds Array of schema IDs.
-	 * @param int $limit Maximum number of objects to return.
-	 * @param int $offset Offset for pagination.
-	 *
-	 * @return ObjectEntity[] Array of object entities.
-	 *
-	 * @psalm-return list<ObjectEntity>
-	 */
-	public function findBySchemas(array $schemaIds, int $limit = 100, int $offset = 0): array {
-		return [];
-	}//end findBySchemas()
 }//end class


### PR DESCRIPTION
`MagicMapper::countBySchemas()` returns `0` and `MagicMapper::findBySchemas()`
returns `[]`, unconditionally. Neither has a caller: measured zero references
across `lib/`, `src/`, `tests/` and `appinfo/` outside their own definitions.

They are the shape this repository has been removing all week. A future caller
would get "no objects in these schemas" from a method that never looked, with
nothing in the answer to suggest doubt. Whoever needs to count or find across
schemas should write it against the magic tables deliberately, the way
`RetentionRowScanner` does, rather than inherit a lie. Same reasoning as the
dead destruction query in #3617 and the orphaned required-fields validator in
#3618.

## Left in place on purpose

`getSizeDistributionChartData()` also answers with an empty chart, but it HAS a
caller (`DashboardService::getObjectsBySizeChartData`), so deleting it would
break the dashboard rather than clean it. The five-bucket query was never
ported off the blob table, which is why that chart is empty on every instance.
Implementing it against the magic tables is a separate change, recorded in
#3658 and still open.

## Verification

| Gate | Result |
| --- | --- |
| phpcs | exit 0 |
| phpunit `tests/Unit/Db` | 1609 tests, exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
