### PR TITLE
fix(mapping): the sandbox allows json_decode, so it must allow json_encode

### DIFF
--- a/lib/Service/MappingService.php
+++ b/lib/Service/MappingService.php
@@ -173,6 +173,21 @@ class MappingService {
 				'b64enc',
 				'b64dec',
 				'json_decode',
+				// Twig core's own filter, and the counterpart to the
+				// `json_decode` above it. It was missing, so a stored mapping
+				// that encodes a value to JSON failed at RENDER with a Twig
+				// SecurityError naming a filter, nowhere near the mapping the
+				// operator was looking at. dossiq stores several ZGW
+				// properties as JSON text and encodes them in twelve of its
+				// default mappings; two of those sit in the setUp of the VNG
+				// ZGW contract collections, so the zaaktype create 400ed and
+				// took every later request in the collection with it.
+				// See #3663.
+				//
+				// It is a pure value transform. The policy already denies
+				// every method and property, so this widens nothing an
+				// attacker can reach.
+				'json_encode',
 				'zgw_enum',
 				'zgw_enum_reverse',
 				'zgw_extract_uuid',

--- a/tests/Unit/Service/MappingServiceTest.php
+++ b/tests/Unit/Service/MappingServiceTest.php
@@ -1229,4 +1229,36 @@ class MappingServiceTest extends TestCase {
 		$this->assertSame(['5.0', '6.0'], $result[2]);
 	}
 
+
+	/**
+	 * The sandbox allows json_decode and must allow json_encode with it.
+	 *
+	 * These two are counterparts, and only one of them was on the allowlist.
+	 * A stored mapping that encodes a value to JSON then failed at render with
+	 * a Twig SecurityError naming a filter, which reads as a broken mapping
+	 * rather than a policy gap. See #3663.
+	 */
+	public function testSandboxAllowsJsonEncode(): void {
+		$entity = $this->createMapping(['out' => '{{ items | json_encode }}']);
+
+		$result = $this->service->executeMapping($entity, ['items' => ['a', 'b']]);
+
+		$this->assertSame('["a","b"]', $result['out']);
+	}
+
+	/**
+	 * A filter nobody allowlisted is still refused.
+	 *
+	 * Without this, the test above would also pass on a sandbox that had been
+	 * switched off entirely.
+	 */
+	public function testSandboxStillRefusesAFilterItDoesNotAllow(): void {
+		$entity = $this->createMapping(['out' => '{{ value | striptags }}']);
+
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('Filter "striptags" is not allowed');
+
+		$this->service->executeMapping($entity, ['value' => '<b>x</b>']);
+	}
+
 }


### PR DESCRIPTION
Closes #3663.

## What was wrong

The Twig `SecurityPolicy` in `MappingService::__construct()` allowlists `json_decode` and not `json_encode`. Both are ordinary filters over a value. Only one of them worked.

A stored mapping that encodes a value to JSON failed at render, not at save, with a Twig `SecurityError`:

```
Error for mapping: zgw-inbound-caseType, key: productsOrServices,
value: {{ productenOfDiensten | json_encode }} and message:
Filter "json_encode" is not allowed in "__string_template__6b5e..." at line 1.
```

That message names a filter, so it reads as a broken mapping rather than a policy gap, and the operator looking at the mapping sees nothing wrong with it.

## What this changes

`json_encode` joins `json_decode` on the allowlist. It is a pure value transform and the policy already denies every method and every property, so nothing an attacker can reach gets wider.

## Tests

Two, in `tests/Unit/Service/MappingServiceTest.php`:

- `testSandboxAllowsJsonEncode` renders `{{ items | json_encode }}` and asserts the JSON comes back.
- `testSandboxStillRefusesAFilterItDoesNotAllow` asserts `striptags` is still refused. Without it the first test would also pass on a sandbox that had been switched off entirely, which is the failure mode worth guarding.

Measured before the fix, with only the policy line reverted: `testSandboxAllowsJsonEncode` errors with the exact SecurityError above, `testSandboxStillRefusesAFilterItDoesNotAllow` passes. After: both pass.

## Who was waiting on this

dossiq stores several ZGW properties as JSON text and encodes them in twelve of its default ZGW mappings. Two sit in the setUp of the VNG ZGW contract collections, so `POST /api/zgw/catalogi/v1/zaaktypen` answered 400 and every later request in the collection read an unset `{{zaaktype_url}}`. dossiq pins openregister at `development` in CI, so this lands there first. See ConductionNL/dossiq#2460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
