### PR TITLE
Add a provider lifecycle mode so available-actions can answer for an app-owned state machine

### DIFF
--- a/lib/Controller/TransitionController.php
+++ b/lib/Controller/TransitionController.php
@@ -28,6 +28,7 @@ namespace OCA\OpenRegister\Controller;
 
 use OCA\OpenRegister\Exception\HookStoppedException;
 use OCA\OpenRegister\Exception\InvalidTransitionInputException;
+use OCA\OpenRegister\Exception\LifecycleProviderException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCP\AppFramework\Controller;
@@ -152,6 +153,22 @@ class TransitionController extends Controller {
 			return new JSONResponse(
 				['error' => $e->getMessage()],
 				Http::STATUS_FORBIDDEN
+			);
+		} catch (LifecycleProviderException $e) {
+			// A provider-mode lifecycle could not be read: the declared tag
+			// resolves to nothing, or the app service threw while answering.
+			// Caught BEFORE the RuntimeException branch it extends, and
+			// deliberately NOT collapsed into an empty action list.
+			//
+			// A client reading this endpoint treats 404 as "this object has
+			// no lifecycle" and any other failure as "could not read", but
+			// `{"actions": []}` is a successful answer meaning "no moves from
+			// here" — so a swallowed provider failure would render as a dead
+			// timeline nobody knows is broken. 502 says the truthful thing:
+			// OpenRegister asked an upstream and did not get an answer.
+			return new JSONResponse(
+				['error' => $e->getMessage()],
+				Http::STATUS_BAD_GATEWAY
 			);
 		} catch (RuntimeException $e) {
 			return new JSONResponse(

--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -1180,6 +1180,14 @@ class SchemaMapper extends QBMapper {
 		// An unknown `executionMode`, a required input beside `autoWhen` and an
 		// `autoWhen` on a graph block each describe a move that can never
 		// happen as written. And no register carries either key yet.
+		//
+		// The two `provider` codes join them on the same test. A mistyped
+		// provider tag, or a `provider` declared beside `transitions`, does not
+		// fail at save time: it fails on a GET, when the client asks what the
+		// object can do and OpenRegister cannot resolve the app service that
+		// knows. Stored advisory, that is a lifecycle an author believes is
+		// wired and a user sees as a dead timeline. And `provider` is new, so
+		// no register carries the key yet.
 		$blocking = array_values(
 			array_filter(
 				$errors,
@@ -1192,6 +1200,8 @@ class SchemaMapper extends QBMapper {
 						'lifecycle-execution-mode-malformed',
 						'lifecycle-autowhen-requires-input',
 						'lifecycle-autowhen-graph-unsupported',
+						'lifecycle-provider-invalid',
+						'lifecycle-provider-mode-conflict',
 					],
 					true
 				)

--- a/lib/Exception/LifecycleProviderException.php
+++ b/lib/Exception/LifecycleProviderException.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * OpenRegister LifecycleProviderException
+ *
+ * Raised when a provider-mode lifecycle cannot be read: the declared tag
+ * resolves to nothing, resolves to the wrong type, or the provider itself
+ * throws while answering.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Exception;
+
+use RuntimeException;
+
+/**
+ * A provider-mode lifecycle could not be read.
+ *
+ * Extends `RuntimeException` so every existing lifecycle catch site keeps
+ * behaving as it did, and is a distinct type so the one caller that must
+ * tell the two apart can: `TransitionController::availableActions()` maps
+ * an ordinary `RuntimeException` to 404 "no such object" and this to 502
+ * "the provider could not answer". Collapsing the second into an empty
+ * action list is the bug this class exists to prevent — a client cannot
+ * tell a silent failure from a state with genuinely no moves.
+ *
+ * Distinct from `ProviderUnavailableException`, which classifies external
+ * integration failures with its own `CAUSE_*` vocabulary and maps to 503.
+ */
+class LifecycleProviderException extends RuntimeException {
+}//end class

--- a/lib/Lifecycle/LifecycleActionProviderInterface.php
+++ b/lib/Lifecycle/LifecycleActionProviderInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * OpenRegister LifecycleActionProviderInterface
+ *
+ * Public contract apps implement to answer "which lifecycle moves does this
+ * object offer right now" when the answer cannot be written in the schema.
+ * Providers are registered via DI tag; the schema's
+ * `x-openregister-lifecycle.provider` field names the tag.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Lifecycle
+ * @package  OCA\OpenRegister\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Lifecycle;
+
+/**
+ * Apps implement this interface to supply an object's available actions.
+ *
+ * This is the third lifecycle mode, beside the schema's static `transitions`
+ * map and its `graph` block. It exists for state machines whose shape is data
+ * rather than schema: a per-object workflow template, a per-case-type status
+ * list, a policy table an administrator edits. OpenRegister should not learn
+ * an app's model to answer such a question, so it delegates exactly as it
+ * already delegates guards (`LifecycleGuardInterface`) and actions
+ * (`LifecycleActionInterface`).
+ *
+ * Providers are read-only — they MUST NOT mutate the object, and MUST NOT
+ * write anything derived from it. They are called on a GET request that the
+ * caller may repeat at will. Side effects (notifications, cascades,
+ * derived-field maintenance) belong on `ObjectTransitionedEvent` listeners,
+ * not in the provider.
+ *
+ * A provider that cannot answer MUST throw. Returning an empty list says
+ * "this object genuinely offers no moves", which a client renders as a dead
+ * but legitimate timeline; a throw is reported to the caller as an upstream
+ * failure (HTTP 502) instead, so the two are never confused.
+ */
+interface LifecycleActionProviderInterface {
+	/**
+	 * List the actions the object offers from its current state.
+	 *
+	 * Entries are published to the client in declaration order. `inputs` is
+	 * normalised by OpenRegister through the same allowlist the write path
+	 * uses, so a malformed entry is dropped rather than published. The
+	 * optional `label` carries a human-readable name for the target state,
+	 * and the optional `blocked` marks a move the object can see but cannot
+	 * take yet, its reason belonging in `description`.
+	 *
+	 * @param array<string, mixed> $object The loaded object payload at its current state.
+	 * @param string $userId The uid of the caller.
+	 *
+	 * @return list<array{action:string,to:string,requires:?string,description:?string,inputs:list<array{field:string,required:bool}>,label?:string,blocked?:bool}>
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function availableActions(array $object, string $userId): array;
+}//end interface

--- a/lib/Service/Lifecycle/LifecycleActionProviderRegistry.php
+++ b/lib/Service/Lifecycle/LifecycleActionProviderRegistry.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * OpenRegister LifecycleActionProviderRegistry
+ *
+ * Resolves an annotation's `provider` DI tag to a concrete
+ * `LifecycleActionProviderInterface` instance. Apps register providers via
+ * Application's `registerService()` keyed by tag, or let Nextcloud autowire
+ * the FQCN the annotation names.
+ *
+ * Cache per request — several reads of the same object during one request
+ * reuse the resolved instance.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Service
+ * @package  OCA\OpenRegister\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Lifecycle;
+
+use OCA\OpenRegister\Exception\LifecycleProviderException;
+use OCA\OpenRegister\Lifecycle\LifecycleActionProviderInterface;
+use OCP\IServerContainer;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves DI tag → provider instance.
+ *
+ * Missing tag is fail-closed, the same policy `LifecycleGuardRegistry` and
+ * `LifecycleActionRegistry` enforce. It matters more here than for either of
+ * them: an unresolved provider that returned an empty list would render as a
+ * lifecycle with no moves, which is indistinguishable from a correct answer.
+ * So it throws, and the controller reports 502.
+ *
+ * Not declared `final`: the engine tests substitute a registry that resolves
+ * without a live container, mirroring `LifecycleActionRegistry`'s rationale.
+ */
+class LifecycleActionProviderRegistry {
+
+	/**
+	 * Per-request cache.
+	 *
+	 * @var array<string, LifecycleActionProviderInterface>
+	 */
+	private array $cache = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ContainerInterface $container OR app container used to resolve provider services first.
+	 * @param IServerContainer $serverContainer NC server container used as fallback for FQCN-tagged providers in other apps.
+	 * @param LoggerInterface $logger Logger for provider resolution diagnostics.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly IServerContainer $serverContainer,
+		private readonly LoggerInterface $logger,
+	) {
+	}//end __construct()
+
+	/**
+	 * Resolve a provider tag to its registered implementation.
+	 *
+	 * @param string $tag DI service tag or FQCN (e.g. `OCA\Dossiq\Lifecycle\CaseActionProvider`).
+	 *
+	 * @return LifecycleActionProviderInterface
+	 *
+	 * @throws LifecycleProviderException When the tag is not registered or the resolved service does not implement the interface.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function resolve(string $tag): LifecycleActionProviderInterface {
+		if (isset($this->cache[$tag]) === true) {
+			return $this->cache[$tag];
+		}
+
+		$instance = null;
+		$errors = [];
+		// Try OR's app container first (covers OR-internal providers) and
+		// fall back to the injected server container (covers FQCN-based
+		// references to providers in other apps that Nextcloud can autowire).
+		// The server container is injected via OCP\IServerContainer rather
+		// than reached through the static \OC::$server accessor, which lib/
+		// bans.
+		foreach ([$this->container, $this->serverContainer] as $candidate) {
+			try {
+				$instance = $candidate->get($tag);
+				break;
+			} catch (\Throwable $e) {
+				$errors[] = $e->getMessage();
+			}
+		}
+
+		if ($instance === null) {
+			$this->logger->error(
+				sprintf('Lifecycle provider tag "%s" could not be resolved: %s', $tag, implode(' | ', $errors))
+			);
+			throw new LifecycleProviderException(
+				message: sprintf('Lifecycle provider "%s" is not registered.', $tag)
+			);
+		}
+
+		if (($instance instanceof LifecycleActionProviderInterface) === false) {
+			throw new LifecycleProviderException(
+				message: sprintf(
+					'Service "%s" does not implement %s.',
+					$tag,
+					LifecycleActionProviderInterface::class
+				)
+			);
+		}
+
+		$this->cache[$tag] = $instance;
+		return $instance;
+	}//end resolve()
+}//end class

--- a/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
+++ b/lib/Service/Lifecycle/LifecycleAnnotationValidator.php
@@ -68,6 +68,14 @@ final class LifecycleAnnotationValidator {
 			$annotation['field'] = $annotation['property'];
 		}
 
+		// Provider mode: checked BEFORE graph so an annotation that declares
+		// both is refused by the provider-mode conflict rule below, with a
+		// message naming the real mistake, instead of being shape-checked as
+		// a graph block that happens to carry a stray key.
+		if (isset($annotation['provider']) === true) {
+			return $this->validateProviderMode(annotation: $annotation, schema: $schema);
+		}
+
 		// Graph mode: when a non-empty `graph` block is declared, the lifecycle
 		// field is a `$ref` with no enum, so shape-check the graph block instead
 		// of the static `transitions`/enum contract. Static-only schemas fall
@@ -286,6 +294,129 @@ final class LifecycleAnnotationValidator {
 
 		return $errors;
 	}//end validate()
+
+	/**
+	 * Validate a provider-mode annotation.
+	 *
+	 * Provider mode delegates the whole state machine to an app service, so
+	 * the schema cannot be asked what the states are: the enum requirement is
+	 * relaxed exactly as it is for graph mode, where the field is a `$ref`.
+	 * What IS checked is that the delegation can be performed at all, because
+	 * a provider that resolves to nothing fails at render time, on a GET, in
+	 * front of a user.
+	 *
+	 * Declaring `transitions` or `graph` beside `provider` is REFUSED rather
+	 * than resolved by precedence. The engine does have a precedence order,
+	 * but an author who wrote two modes on one field meant one of them, and
+	 * the one the engine drops would silently never run. That is the same
+	 * mistake the graph `condition` refusal already guards against: a rule
+	 * that reads as enforced and is not.
+	 *
+	 * @param array<string, mixed> $annotation The normalised annotation block.
+	 * @param array<string, mixed> $schema Full schema definition.
+	 *
+	 * @return array<int, array{code: string, message: string}> List of errors (empty = valid).
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function validateProviderMode(array $annotation, array $schema): array {
+		$errors = [];
+
+		// `provider` must name something resolvable: a non-empty string, a DI
+		// tag or an FQCN.
+		$provider = ($annotation['provider'] ?? null);
+		if (is_string($provider) === false || trim($provider) === '') {
+			$errors[] = [
+				'code' => 'lifecycle-provider-invalid',
+				'message' => 'x-openregister-lifecycle.provider must be a non-empty string naming a '
+					. 'registered LifecycleActionProviderInterface service.',
+			];
+		}
+
+		$errors = array_merge($errors, $this->validateProviderField(annotation: $annotation, schema: $schema));
+
+		// `initial` (optional): accept the literal-string form or the object
+		// form `{ from, field }`, as graph mode does.
+		if (isset($annotation['initial']) === true) {
+			$initialError = $this->validateInitialForm(initial: $annotation['initial']);
+			if ($initialError !== null) {
+				$errors[] = $initialError;
+			}
+		}
+
+		return array_merge($errors, $this->validateProviderModeConflicts(annotation: $annotation));
+	}//end validateProviderMode()
+
+	/**
+	 * Check a provider-mode `field` against the schema's properties.
+	 *
+	 * `field` stays required and non-empty, but the `enum`/`type:string`
+	 * constraint is relaxed: in provider mode the app owns the state
+	 * vocabulary, so the schema has nothing to enumerate.
+	 *
+	 * @param array<string, mixed> $annotation The normalised annotation block.
+	 * @param array<string, mixed> $schema Full schema definition.
+	 *
+	 * @return array<int, array{code: string, message: string}> List of errors (empty = valid).
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function validateProviderField(array $annotation, array $schema): array {
+		$field = ($annotation['field'] ?? null);
+		if (is_string($field) === false || $field === '') {
+			return [
+				[
+					'code' => 'lifecycle-missing-key',
+					'message' => 'x-openregister-lifecycle is missing required key "field".',
+				],
+			];
+		}
+
+		$properties = ($schema['properties'] ?? []);
+		if (is_array($properties) === true && isset($properties[$field]) === false) {
+			return [
+				[
+					'code' => 'lifecycle-field-missing',
+					'message' => sprintf('x-openregister-lifecycle.field "%s" is not declared in `properties`.', $field),
+				],
+			];
+		}
+
+		return [];
+	}//end validateProviderField()
+
+	/**
+	 * Refuse a second lifecycle mode declared beside `provider`.
+	 *
+	 * An empty `transitions: {}` or `graph: {}` declares no second mode, so it
+	 * is not a conflict; anything else is. See {@see validateProviderMode()}
+	 * for why this refuses rather than leaning on the engine's precedence.
+	 *
+	 * @param array<string, mixed> $annotation The normalised annotation block.
+	 *
+	 * @return array<int, array{code: string, message: string}> List of errors (empty = valid).
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function validateProviderModeConflicts(array $annotation): array {
+		$errors = [];
+		foreach (['transitions', 'graph'] as $rival) {
+			if (isset($annotation[$rival]) === false || $annotation[$rival] === []) {
+				continue;
+			}
+
+			$errors[] = [
+				'code' => 'lifecycle-provider-mode-conflict',
+				'message' => sprintf(
+					'x-openregister-lifecycle declares both `provider` and `%s`. A field has one '
+					. 'lifecycle mode: declare the transitions in the schema or in the provider, not both.',
+					$rival
+				),
+			];
+		}
+
+		return $errors;
+	}//end validateProviderModeConflicts()
 
 	/**
 	 * Validate a graph-mode `x-openregister-lifecycle` annotation.

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -35,6 +35,7 @@ use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\OpenRegister\Exception\HookStoppedException;
 use OCA\OpenRegister\Exception\InvalidTransitionInputException;
+use OCA\OpenRegister\Exception\LifecycleProviderException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
@@ -52,6 +53,15 @@ use Throwable;
  * Not declared `final`: TransitionControllerTest doubles this class, and
  * the controller injects it by concrete type. If sealing is reintroduced,
  * extract an interface for the controller to depend on first.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) The third lifecycle mode
+ * (`provider`) is what carried this past the 1000-line threshold. The three
+ * modes answer one question and share one published contract, so splitting
+ * them across classes would duplicate `publishedInputs()` and let the shape
+ * a client reads drift per mode, which is the failure this change exists to
+ * avoid. Graph-mode derivation is the extractable block if the class grows
+ * again; it is left alone here so the provider change stays readable as a
+ * diff.
  */
 class TransitionEngine {
 	/**
@@ -77,6 +87,14 @@ class TransitionEngine {
 	 * @param LoggerInterface $logger Logger for post-commit listener failures.
 	 * @param LifecycleWriteBoundary $writeBoundary Names the transition for the listeners and wraps
 	 *                               the request-scoped automatic-transition pass.
+	 * @param LifecycleActionProviderRegistry $providerRegistry Resolves a provider-mode annotation's
+	 *                               `provider` tag to the app service that answers available actions.
+	 *
+	 * @SuppressWarnings(PHPMD.ExcessiveParameterList) Ten collaborators, all
+	 * constructor-injected because Nextcloud's DI offers no other route. The
+	 * tenth is the provider registry; folding it into an existing collaborator
+	 * would hide a lifecycle dependency inside something that is not about
+	 * lifecycles, which reads worse than the count.
 	 *
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 * @spec openspec/changes/lifecycle-declarative-conditions/specs/object-lifecycle/spec.md
@@ -92,6 +110,7 @@ class TransitionEngine {
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly LifecycleWriteBoundary $writeBoundary,
+		private readonly LifecycleActionProviderRegistry $providerRegistry,
 	) {
 	}//end __construct()
 
@@ -457,7 +476,12 @@ class TransitionEngine {
 	 * transition accepts no payload", which is exactly what the allowlist in
 	 * {@see resolveTransitionInputs()} enforces.
 	 *
-	 * @return list<array{action:string,to:string,requires:?string,description:?string,inputs:list<array{field:string,required:bool}>,label?:string}>
+	 * Three modes answer this question. A static `transitions` map is read
+	 * here; a `provider` tag delegates to the app that owns the state
+	 * machine; a `graph` block derives moves from FK-scoped siblings. Static
+	 * wins over both delegating modes wherever more than one is declared.
+	 *
+	 * @return list<array{action:string,to:string,requires:?string,description:?string,inputs:list<array{field:string,required:bool}>,label?:string,blocked?:bool}>
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity) RBAC check + missing-object guard + annotation-absent
 	 * guard + per-transition from/requires/description checks each add one branch; none can be removed
@@ -511,9 +535,17 @@ class TransitionEngine {
 		$transitions = (array)($annotation['transitions'] ?? []);
 
 		// Static transitions take precedence. When no non-empty static map is
-		// declared but a `graph` block is, derive actions from FK-scoped
-		// siblings at runtime (design: mode selection & precedence).
+		// declared, fall through to the delegating modes in declaration order:
+		// `provider` (the app answers) before `graph` (FK-scoped siblings at
+		// runtime). Mode selection & precedence: a schema that declares a
+		// static map keeps it, whatever else it says, so an annotation that
+		// grows a second mode never silently loses the transitions it had.
 		if ($transitions === []) {
+			$provider = trim((string)($annotation['provider'] ?? ''));
+			if ($provider !== '') {
+				return $this->deriveProviderActions(object: $object, tag: $provider);
+			}
+
 			$graph = (array)($annotation['graph'] ?? []);
 			if ($graph !== []) {
 				return $this->deriveGraphActions(object: $object, graph: $graph, field: $field);
@@ -555,6 +587,124 @@ class TransitionEngine {
 
 		return $available;
 	}//end availableActions()
+
+	/**
+	 * Ask the app for a provider-mode object's available actions.
+	 *
+	 * Provider mode exists for state machines whose shape is data rather than
+	 * schema — a per-object workflow template, a per-case-type status list, a
+	 * policy table an administrator edits. OpenRegister does not learn that
+	 * model; it resolves the declared tag and asks, exactly as it already
+	 * delegates guards and actions.
+	 *
+	 * Two failure modes are deliberately NOT collapsed into an empty list.
+	 * An unresolved tag throws out of the registry, and a provider that
+	 * throws while answering is wrapped here. Both reach the controller as
+	 * `LifecycleProviderException`, which answers 502: an empty list is a
+	 * legitimate answer ("this object offers no moves"), so a silent failure
+	 * would be indistinguishable from one and would render as a dead
+	 * timeline the client believes is correct.
+	 *
+	 * @param ObjectEntity $object The object whose actions are being listed.
+	 * @param string $tag The `provider` DI tag off the annotation.
+	 *
+	 * @return list<array{action:string,to:string,requires:?string,description:?string,inputs:list<array{field:string,required:bool}>,label?:string,blocked?:bool}>
+	 *
+	 * @throws LifecycleProviderException When the tag resolves to nothing, resolves to the
+	 *                          wrong type, or the provider throws while answering.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function deriveProviderActions(ObjectEntity $object, string $tag): array {
+		$provider = $this->providerRegistry->resolve(tag: $tag);
+		$userId = (string)($this->userSession->getUser()?->getUID() ?? '');
+
+		try {
+			$entries = $provider->availableActions(
+				object: ($object->getObject() ?? []),
+				userId: $userId
+			);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				sprintf(
+					'Lifecycle provider "%s" failed to list actions for object "%s": %s',
+					$tag,
+					(string)$object->getUuid(),
+					$e->getMessage()
+				),
+				['exception' => $e]
+			);
+			throw new LifecycleProviderException(
+				message: sprintf('Lifecycle provider "%s" could not list available actions.', $tag),
+				code: 0,
+				previous: $e
+			);
+		}//end try
+
+		return $this->publishProviderActions(entries: $entries);
+	}//end deriveProviderActions()
+
+	/**
+	 * Normalise a provider's answer onto the published action contract.
+	 *
+	 * `inputs` runs through the SAME {@see publishedInputs()} the static and
+	 * graph modes use, so the contract a client reads cannot drift per mode
+	 * and a malformed entry is dropped rather than published. An entry that
+	 * names no action is skipped, mirroring how a malformed static transition
+	 * spec is skipped rather than published half-formed. `label` and
+	 * `blocked` are carried through only when the provider set them, so the
+	 * response shape of a provider that does not use them is byte-identical
+	 * to a static one.
+	 *
+	 * @param array<int|string, mixed> $entries Whatever the provider returned.
+	 *
+	 * @return list<array{action:string,to:string,requires:?string,description:?string,inputs:list<array{field:string,required:bool}>,label?:string,blocked?:bool}>
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function publishProviderActions(array $entries): array {
+		$published = [];
+		foreach ($entries as $entry) {
+			if (is_array($entry) === false) {
+				continue;
+			}
+
+			$action = (string)($entry['action'] ?? '');
+			if ($action === '') {
+				continue;
+			}
+
+			$requires = null;
+			if (isset($entry['requires']) === true) {
+				$requires = (string)$entry['requires'];
+			}
+
+			$description = null;
+			if (isset($entry['description']) === true) {
+				$description = (string)$entry['description'];
+			}
+
+			$item = [
+				'action' => $action,
+				'to' => (string)($entry['to'] ?? ''),
+				'requires' => $requires,
+				'description' => $description,
+				'inputs' => $this->publishedInputs(inputs: (array)($entry['inputs'] ?? [])),
+			];
+
+			if (isset($entry['label']) === true) {
+				$item['label'] = (string)$entry['label'];
+			}
+
+			if (isset($entry['blocked']) === true) {
+				$item['blocked'] = (bool)$entry['blocked'];
+			}
+
+			$published[] = $item;
+		}//end foreach
+
+		return $published;
+	}//end publishProviderActions()
 
 	/**
 	 * Derive the candidate transitions for a graph-mode object.

--- a/openspec/specs/object-lifecycle/spec.md
+++ b/openspec/specs/object-lifecycle/spec.md
@@ -943,6 +943,102 @@ static-mode semantics unchanged (no auto-seed behaviour change for static schema
 - **WHEN** the object is created
 - **THEN** the seed step MUST be a no-op and the `status` field MUST remain unset
 
+### Requirement: Lifecycle provider mode delegates available actions to an app service
+
+The engine MUST support a third lifecycle mode for schemas whose state machine
+is data rather than annotation: a per-object workflow template, a per-case-type
+status list, or a policy table an administrator edits. When
+`x-openregister-lifecycle` declares a non-empty `provider` string and no
+non-empty static `transitions` map, `TransitionEngine::availableActions()` SHALL
+resolve that value through `LifecycleActionProviderRegistry` and SHALL publish
+what the resolved `LifecycleActionProviderInterface` answers. A provider is
+read-only: it MUST NOT mutate the object, because it is called on a GET the
+caller may repeat at will.
+
+Mode precedence SHALL be static, then provider, then graph. A schema declaring a
+non-empty `transitions` map SHALL keep it whatever else it declares, so an
+annotation that grows a second mode never silently loses the transitions it had.
+
+Each published entry SHALL carry `action`, `to`, `requires`, `description` and
+`inputs`, and MAY carry `label` and `blocked`. The `inputs` list SHALL be
+normalised through the same code that normalises a static transition's declared
+`inputs`, so what a client is told a transition accepts is exactly what the write
+path will accept.
+
+#### Scenario: Provider answer is published
+- **GIVEN** a schema whose `x-openregister-lifecycle` declares a `provider` tag and no static `transitions`
+- **WHEN** `availableActions()` is called for an object of that schema
+- **THEN** the response MUST contain the actions the registered provider answered, in the order it answered them
+
+#### Scenario: Static transitions take precedence over a provider
+- **GIVEN** a schema declaring both a non-empty `transitions` map and a `provider` tag
+- **WHEN** `availableActions()` is called for an object of that schema
+- **THEN** the actions MUST be derived from the static `transitions` map only
+- **AND** the provider MUST NOT be resolved
+
+#### Scenario: Provider inputs are normalised onto the published contract
+- **GIVEN** a provider that answers an action whose `inputs` list contains an entry naming no field
+- **WHEN** `availableActions()` is called
+- **THEN** that entry MUST be dropped and the remaining entries MUST be published as `{field, required}` pairs
+
+### Requirement: A provider that cannot answer MUST fail closed rather than return an empty list
+
+An empty action list is a successful answer meaning the object offers no moves
+from its current state, so a provider failure MUST NOT be reported as one. When
+the declared `provider` resolves to no service, resolves to a service that does
+not implement `LifecycleActionProviderInterface`, or throws while answering, the
+engine SHALL raise `LifecycleProviderException` and
+`TransitionController::availableActions()` SHALL answer HTTP 502. The existing
+403 for a caller without `read` permission and 404 for a missing object SHALL be
+unchanged.
+
+Because a broken provider declaration fails at read time rather than at save
+time, `lifecycle-provider-invalid` and `lifecycle-provider-mode-conflict` SHALL
+refuse the schema save, unlike the advisory lifecycle findings that are stored as
+written.
+
+#### Scenario: Unresolvable provider answers 502
+- **GIVEN** a schema declaring a `provider` tag that no app has registered
+- **WHEN** a client calls the available-actions endpoint for an object of that schema
+- **THEN** the response status MUST be 502
+- **AND** the response MUST NOT contain an empty `actions` list
+
+#### Scenario: Provider with no moves answers an empty list
+- **GIVEN** a registered provider that answers an empty list for the object's current state
+- **WHEN** a client calls the available-actions endpoint
+- **THEN** the response status MUST be 200 and `actions` MUST be an empty list
+
+### Requirement: Schema validation accepts the provider block and refuses two modes on one field
+
+`LifecycleAnnotationValidator` SHALL accept a `provider` key on
+`x-openregister-lifecycle` and SHALL shape-check it: `provider` MUST be a
+non-empty string, `field` MUST be a non-empty string declared in `properties`,
+and the `enum`/`type:string` constraint on that field SHALL be relaxed as it is
+for graph mode, because the app owns the state vocabulary. `initial` MAY be
+either the literal-string form or the object form `{ "from": ..., "field": ... }`.
+
+Declaring a non-empty `transitions` map or a non-empty `graph` block beside
+`provider` SHALL be refused with `lifecycle-provider-mode-conflict`. The engine
+does resolve the ambiguity by precedence, but the mode it drops would read as
+declared and never run, which is the failure the graph `condition` refusal
+already guards against. An empty `transitions` or `graph` value declares no
+second mode and SHALL NOT be refused.
+
+#### Scenario: Valid provider annotation passes validation
+- **GIVEN** a schema whose `x-openregister-lifecycle` declares a `provider` tag, a `field` present in `properties` with no enum, and an object-form `initial`
+- **WHEN** the schema is validated
+- **THEN** `LifecycleAnnotationValidator` MUST return no errors
+
+#### Scenario: Empty provider is rejected
+- **GIVEN** an annotation whose `provider` is an empty string
+- **WHEN** the schema is validated
+- **THEN** the validator MUST return `lifecycle-provider-invalid`
+
+#### Scenario: Two modes on one field are rejected
+- **GIVEN** an annotation declaring both `provider` and a non-empty `transitions` map
+- **WHEN** the schema is validated
+- **THEN** the validator MUST return `lifecycle-provider-mode-conflict`
+
 ### Requirement: A transition MAY declare `actions[]` that OpenRegister MUST execute on any transition form
 
 OpenRegister MUST execute the `actions[]` a schema declares on a lifecycle

--- a/tests/Unit/Controller/TransitionControllerTest.php
+++ b/tests/Unit/Controller/TransitionControllerTest.php
@@ -26,6 +26,7 @@ namespace Unit\Controller;
 use OCA\OpenRegister\Controller\TransitionController;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Exception\InvalidTransitionInputException;
+use OCA\OpenRegister\Exception\LifecycleProviderException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCP\AppFramework\Http;
@@ -238,4 +239,29 @@ class TransitionControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 	}//end testAvailableActionsReturns404OnMissingObject()
+
+	/**
+	 * A provider-mode lifecycle that cannot be read answers 502, and the
+	 * status is what carries the meaning: a client reads 404 as "no
+	 * lifecycle" and an empty action list as "no moves from here", so
+	 * neither of those may stand in for "could not read". Distinct from the
+	 * 403 and 404 cases above, which are unchanged.
+	 *
+	 * @return void
+	 */
+	public function testAvailableActionsReturns502WhenTheProviderCannotAnswer(): void {
+		$this->engine->method('availableActions')->willThrowException(
+			new LifecycleProviderException(
+				'Lifecycle provider "OCA\\Dossiq\\Lifecycle\\CaseActionProvider" is not registered.'
+			)
+		);
+
+		$response = $this->controller->availableActions('obj-1');
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+		$body = $response->getData();
+		$this->assertIsArray($body);
+		$this->assertArrayNotHasKey('actions', $body);
+		$this->assertStringContainsString('is not registered', (string)($body['error'] ?? ''));
+	}//end testAvailableActionsReturns502WhenTheProviderCannotAnswer()
 }//end class

--- a/tests/Unit/Db/SchemaMapperLifecycleConditionTest.php
+++ b/tests/Unit/Db/SchemaMapperLifecycleConditionTest.php
@@ -242,4 +242,59 @@ class SchemaMapperLifecycleConditionTest extends TestCase {
 			)
 		);
 	}//end testAValidConditionSavesSilently()
+
+	/**
+	 * A mistyped provider tag refuses the save.
+	 *
+	 * Stored advisory, it would fail nowhere until a client asked what the
+	 * object can do, on a GET, and got a 502 for a schema whose author was
+	 * told the save succeeded.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyProviderRefusesTheSave(): void {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/^Invalid .*lifecycle-provider-invalid/');
+
+		$this->validate(['field' => 'status', 'provider' => '']);
+	}//end testAnEmptyProviderRefusesTheSave()
+
+	/**
+	 * Two lifecycle modes on one field refuse the save, for the same reason
+	 * the validator refuses them: the mode the engine drops would read as
+	 * declared and never run.
+	 *
+	 * @return void
+	 */
+	public function testTwoModesOnOneFieldRefuseTheSave(): void {
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/^Invalid .*lifecycle-provider-mode-conflict/');
+
+		$this->validate(
+			[
+				'field' => 'status',
+				'provider' => 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider',
+				'transitions' => ['beslissen' => ['from' => ['open'], 'to' => 'besloten']],
+			]
+		);
+	}//end testTwoModesOnOneFieldRefuseTheSave()
+
+	/**
+	 * A well-formed provider declaration saves silently: no refusal, and no
+	 * advisory warning either, so the relaxed enum rule is real rather than
+	 * downgraded to a log line.
+	 *
+	 * @return void
+	 */
+	public function testAValidProviderSavesSilently(): void {
+		$this->logger->expects($this->never())->method('warning');
+
+		$this->validate(
+			[
+				'field' => 'status',
+				'initial' => ['from' => 'caseType', 'field' => 'initialStatus'],
+				'provider' => 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider',
+			]
+		);
+	}//end testAValidProviderSavesSilently()
 }//end class

--- a/tests/Unit/Service/Lifecycle/LifecycleActionProviderRegistryTest.php
+++ b/tests/Unit/Service/Lifecycle/LifecycleActionProviderRegistryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * OpenRegister LifecycleActionProviderRegistry tests
+ *
+ * Exercises the fail-closed policy the provider mode depends on: a tag that
+ * resolves to nothing throws, a tag that resolves to the wrong type throws,
+ * and a resolved provider is cached for the rest of the request.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Tests\Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Exception\LifecycleProviderException;
+use OCA\OpenRegister\Lifecycle\LifecycleActionProviderInterface;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry;
+use OCP\IServerContainer;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry
+ */
+class LifecycleActionProviderRegistryTest extends TestCase {
+	private ContainerInterface $container;
+
+	private IServerContainer $serverContainer;
+
+	private LifecycleActionProviderRegistry $registry;
+
+	protected function setUp(): void {
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->serverContainer = $this->createMock(IServerContainer::class);
+
+		$this->registry = new LifecycleActionProviderRegistry(
+			$this->container,
+			$this->serverContainer,
+			$this->createMock(LoggerInterface::class)
+		);
+	}//end setUp()
+
+	/**
+	 * A provider registered in OpenRegister's own container resolves.
+	 */
+	public function testProviderResolvesFromTheAppContainer(): void {
+		$provider = $this->createMock(LifecycleActionProviderInterface::class);
+		$this->container->method('get')->with('dossiq.case.actions')->willReturn($provider);
+
+		$this->assertSame($provider, $this->registry->resolve('dossiq.case.actions'));
+	}//end testProviderResolvesFromTheAppContainer()
+
+	/**
+	 * An FQCN another app owns is unknown to OpenRegister's container and
+	 * resolves through the server container instead. This is the case the
+	 * annotation's documented shape actually uses.
+	 */
+	public function testProviderResolvesFromTheServerContainerAsFallback(): void {
+		$notFound = new class extends \Exception implements NotFoundExceptionInterface {
+		};
+		$provider = $this->createMock(LifecycleActionProviderInterface::class);
+		$this->container->method('get')->willThrowException($notFound);
+		$this->serverContainer->method('get')->willReturn($provider);
+
+		$this->assertSame($provider, $this->registry->resolve('OCA\\Dossiq\\Lifecycle\\CaseActionProvider'));
+	}//end testProviderResolvesFromTheServerContainerAsFallback()
+
+	/**
+	 * FAIL CLOSED: a tag nothing answers to throws rather than resolving to
+	 * null. A null provider would have to be reported as an empty action
+	 * list, which reads as a legitimate answer.
+	 */
+	public function testMissingProviderFailsClosed(): void {
+		$notFound = new class extends \Exception implements NotFoundExceptionInterface {
+		};
+		$this->container->method('get')->willThrowException($notFound);
+		$this->serverContainer->method('get')->willThrowException($notFound);
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('is not registered');
+
+		$this->registry->resolve('nobody.answers.to.this');
+	}//end testMissingProviderFailsClosed()
+
+	/**
+	 * FAIL CLOSED: a tag that resolves to something not implementing the
+	 * interface throws, naming the interface it fails to implement.
+	 */
+	public function testWrongTypeFailsClosed(): void {
+		$this->container->method('get')->willReturn(new \stdClass());
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('does not implement');
+
+		$this->registry->resolve('wrong.type');
+	}//end testWrongTypeFailsClosed()
+
+	/**
+	 * Resolved once per request: several reads of the same object during one
+	 * request reuse the instance rather than rebuilding it.
+	 */
+	public function testResolutionIsCachedPerRequest(): void {
+		$provider = $this->createMock(LifecycleActionProviderInterface::class);
+		$this->container->expects($this->once())->method('get')->willReturn($provider);
+
+		$this->assertSame($provider, $this->registry->resolve('dossiq.case.actions'));
+		$this->assertSame($provider, $this->registry->resolve('dossiq.case.actions'));
+	}//end testResolutionIsCachedPerRequest()
+}//end class

--- a/tests/Unit/Service/Lifecycle/LifecycleAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Lifecycle/LifecycleAnnotationValidatorTest.php
@@ -620,4 +620,153 @@ class LifecycleAnnotationValidatorTest extends TestCase {
 		]);
 		$this->assertSame([], $errors);
 	}
+
+	// --- Provider mode -----------------------------------------------------
+
+	/**
+	 * The annotation dossiq's case schema will carry: a field the app owns,
+	 * a derived `initial`, and a provider tag. It validates clean, and in
+	 * particular the enum requirement is relaxed exactly as it is for graph
+	 * mode, because in provider mode the app owns the state vocabulary.
+	 */
+	public function testProviderModeValidatesWithoutAnEnum(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'initial' => ['from' => 'caseType', 'field' => 'initialStatus'],
+				'provider' => 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider',
+			],
+			'properties' => ['status' => ['type' => 'string']],
+		]);
+		$this->assertSame([], $errors);
+	}
+
+	/**
+	 * A provider tag that names nothing is refused. It would resolve to
+	 * nothing at render time, on a GET, in front of a user.
+	 */
+	public function testEmptyProviderIsRejected(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'provider' => '   ',
+			],
+			'properties' => ['status' => ['type' => 'string']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('lifecycle-provider-invalid', $codes);
+	}
+
+	/**
+	 * A non-string provider is refused for the same reason.
+	 */
+	public function testNonStringProviderIsRejected(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'provider' => ['class' => 'CaseActionProvider'],
+			],
+			'properties' => ['status' => ['type' => 'string']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('lifecycle-provider-invalid', $codes);
+	}
+
+	/**
+	 * The field still has to exist, even though its enum no longer does.
+	 */
+	public function testProviderFieldMustBeDeclaredInProperties(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'provider' => 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider',
+			],
+			'properties' => ['name' => ['type' => 'string']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('lifecycle-field-missing', $codes);
+	}
+
+	/**
+	 * Two modes on one field are refused rather than settled by precedence,
+	 * mirroring the graph-condition refusal: the mode the engine drops would
+	 * read as declared and never run.
+	 */
+	public function testProviderBesideTransitionsIsRejected(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'provider' => 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider',
+				'transitions' => [
+					'open' => ['from' => ['draft'], 'to' => 'opened'],
+				],
+			],
+			'properties' => ['status' => ['type' => 'string']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('lifecycle-provider-mode-conflict', $codes);
+	}
+
+	/**
+	 * Same rule for the other delegating mode.
+	 */
+	public function testProviderBesideGraphIsRejected(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'provider' => 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider',
+				'graph' => [
+					'schema' => 'statustype',
+					'parentField' => 'caseType',
+					'parentFrom' => 'caseType',
+					'orderField' => 'order',
+					'finalField' => 'isFinal',
+					'allowedMoves' => 'forward',
+				],
+			],
+			'properties' => ['status' => ['type' => 'string']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('lifecycle-provider-mode-conflict', $codes);
+	}
+
+	/**
+	 * An EMPTY `transitions` map declares no second mode, so it is not a
+	 * conflict. Refusing it would break an author who left the key behind
+	 * while moving the state machine into the provider.
+	 */
+	public function testProviderBesideAnEmptyTransitionsMapIsAccepted(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'provider' => 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider',
+				'transitions' => [],
+			],
+			'properties' => ['status' => ['type' => 'string']],
+		]);
+		$this->assertSame([], $errors);
+	}
+
+	/**
+	 * No regression: a graph annotation that carries no `provider` key is
+	 * still validated as a graph block.
+	 */
+	public function testGraphWithoutProviderIsStillGraphValidated(): void {
+		$errors = $this->v->validate([
+			'x-openregister-lifecycle' => [
+				'field' => 'status',
+				'graph' => [
+					'schema' => 'statustype',
+					'parentField' => 'caseType',
+					'parentFrom' => 'caseType',
+					'orderField' => 'order',
+					'finalField' => 'isFinal',
+					'allowedMoves' => 'sideways',
+				],
+			],
+			'properties' => ['status' => ['type' => 'string']],
+		]);
+		$codes = array_column($errors, 'code');
+		$this->assertContains('lifecycle-graph-allowedmoves-invalid', $codes);
+	}
 }

--- a/tests/Unit/Service/Lifecycle/TransitionEngineActionContextTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineActionContextTest.php
@@ -30,6 +30,7 @@ use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
 use OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry;
 use OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
@@ -100,7 +101,8 @@ class TransitionEngineActionContextTest extends TestCase {
 			$this->createMock(RegisterMapper::class),
 			$appConfig,
 			$this->createMock(LoggerInterface::class),
-			new LifecycleWriteBoundary($this->context)
+			new LifecycleWriteBoundary($this->context),
+			$this->createMock(LifecycleActionProviderRegistry::class)
 		);
 	}//end setUp()
 

--- a/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineGraphTest.php
@@ -105,7 +105,8 @@ class TransitionEngineGraphTest extends TestCase {
 			$this->logger,
 			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
 				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
-			)
+			),
+			$this->createMock(\OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry::class)
 		);
 	}//end setUp()
 

--- a/tests/Unit/Service/Lifecycle/TransitionEngineInputsTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineInputsTest.php
@@ -97,7 +97,8 @@ class TransitionEngineInputsTest extends TestCase {
 			$this->logger,
 			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
 				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
-			)
+			),
+			$this->createMock(\OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry::class)
 		);
 	}//end setUp()
 
@@ -500,7 +501,8 @@ class TransitionEngineInputsTest extends TestCase {
 			$this->logger,
 			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
 				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
-			)
+			),
+			$this->createMock(\OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry::class)
 		);
 
 		try {

--- a/tests/Unit/Service/Lifecycle/TransitionEngineProviderTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineProviderTest.php
@@ -1,0 +1,403 @@
+<?php
+
+/**
+ * OpenRegister TransitionEngine provider-mode tests
+ *
+ * Covers the third lifecycle mode: an app service answers available-actions
+ * for a schema whose state machine lives in data rather than in the
+ * annotation. Asserts what is published, that static transitions still win,
+ * that the `inputs` contract is normalised by the same code the other two
+ * modes use, that an unresolvable provider fails closed rather than answering
+ * with an empty list, and that a `blocked` entry keeps its reason.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\LifecycleProviderException;
+use OCA\OpenRegister\Lifecycle\LifecycleActionProviderInterface;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Service\Lifecycle\TransitionEngine
+ */
+class TransitionEngineProviderTest extends TestCase {
+	private const CASE = '00000000-0000-0000-0000-0000000000aa';
+
+	private const TAG = 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider';
+
+	private ObjectService&MockObject $objectService;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private LifecycleActionProviderRegistry&MockObject $registry;
+
+	private LoggerInterface&MockObject $logger;
+
+	private TransitionEngine $engine;
+
+	protected function setUp(): void {
+		$this->objectService = $this->createMock(ObjectService::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registry = $this->createMock(LifecycleActionProviderRegistry::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$permission = $this->createMock(PermissionHandler::class);
+		$permission->method('hasPermission')->willReturn(true);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')
+			->willReturnCallback(
+				static function (string $app, string $key, string $default = '') {
+					return $default;
+				}
+			);
+
+		$this->engine = new TransitionEngine(
+			$this->objectService,
+			$this->schemaMapper,
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(IUserSession::class),
+			$permission,
+			$this->createMock(RegisterMapper::class),
+			$appConfig,
+			$this->logger,
+			new LifecycleWriteBoundary(new LifecycleActionContext()),
+			$this->registry
+		);
+	}//end setUp()
+
+	/**
+	 * The dossiq-shaped case object: a status the schema knows nothing about.
+	 */
+	private function caseObject(string $status = 'in-behandeling'): ObjectEntity {
+		$case = new ObjectEntity();
+		$case->setUuid(self::CASE);
+		$case->setSchema('case');
+		$case->setRegister('1');
+		$case->setObject(['caseType' => 'ct-1', 'status' => $status]);
+		return $case;
+	}//end caseObject()
+
+	/**
+	 * A provider-mode annotation, the shape a delegating schema declares.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function providerAnnotation(): array {
+		return [
+			'field' => 'status',
+			'initial' => ['from' => 'caseType', 'field' => 'initialStatus'],
+			'provider' => self::TAG,
+		];
+	}//end providerAnnotation()
+
+	/**
+	 * @param array<string, mixed> $annotation The lifecycle block to serve.
+	 */
+	private function wire(ObjectEntity $case, array $annotation): void {
+		$this->objectService->method('find')->willReturn($case);
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getConfiguration')->willReturn(['x-openregister-lifecycle' => $annotation]);
+		$this->schemaMapper->method('find')->willReturn($schema);
+	}//end wire()
+
+	/**
+	 * Register a provider returning the given list under the annotation's tag.
+	 *
+	 * @param array<int, mixed> $entries Whatever the app answers with.
+	 */
+	private function provider(array $entries): LifecycleActionProviderInterface&MockObject {
+		$provider = $this->createMock(LifecycleActionProviderInterface::class);
+		$provider->method('availableActions')->willReturn($entries);
+		$this->registry->method('resolve')->with(self::TAG)->willReturn($provider);
+		return $provider;
+	}//end provider()
+
+	/**
+	 * The provider's list is what the endpoint publishes: this is the whole
+	 * point of the mode, and it is the case dossiq's stages widget reads.
+	 */
+	public function testProviderActionsArePublished(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider(
+			[
+				[
+					'action' => 'afhandelen',
+					'to' => 'afgehandeld',
+					'requires' => 'dossiq.case.closeGuard',
+					'description' => 'Sluit de zaak af.',
+					'label' => 'Afgehandeld',
+					'inputs' => [['field' => 'motivering', 'required' => true]],
+				],
+			]
+		);
+
+		$actions = $this->engine->availableActions(self::CASE);
+
+		$this->assertCount(1, $actions);
+		$this->assertSame('afhandelen', $actions[0]['action']);
+		$this->assertSame('afgehandeld', $actions[0]['to']);
+		$this->assertSame('dossiq.case.closeGuard', $actions[0]['requires']);
+		$this->assertSame('Sluit de zaak af.', $actions[0]['description']);
+		$this->assertSame('Afgehandeld', $actions[0]['label']);
+		$this->assertSame([['field' => 'motivering', 'required' => true]], $actions[0]['inputs']);
+	}//end testProviderActionsArePublished()
+
+	/**
+	 * An entry that names no action is skipped, and the rest of the list is
+	 * still published — the same policy a malformed static transition spec
+	 * gets, rather than failing the whole read.
+	 */
+	public function testEntriesWithoutAnActionAreSkipped(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider(
+			[
+				'not-an-array',
+				['to' => 'afgehandeld'],
+				['action' => 'afhandelen', 'to' => 'afgehandeld'],
+			]
+		);
+
+		$actions = $this->engine->availableActions(self::CASE);
+
+		$this->assertCount(1, $actions);
+		$this->assertSame('afhandelen', $actions[0]['action']);
+	}//end testEntriesWithoutAnActionAreSkipped()
+
+	/**
+	 * An action that declares nothing still publishes the contract's own
+	 * nulls and its EMPTY inputs list, so a client reading a provider-mode
+	 * response reads exactly the shape a static one gives it.
+	 */
+	public function testUndeclaredFieldsPublishAsTheContractsDefaults(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider([['action' => 'afhandelen', 'to' => 'afgehandeld']]);
+
+		$actions = $this->engine->availableActions(self::CASE);
+
+		$this->assertNull($actions[0]['requires']);
+		$this->assertNull($actions[0]['description']);
+		$this->assertSame([], $actions[0]['inputs']);
+		$this->assertArrayNotHasKey('label', $actions[0]);
+		$this->assertArrayNotHasKey('blocked', $actions[0]);
+	}//end testUndeclaredFieldsPublishAsTheContractsDefaults()
+
+	/**
+	 * `inputs` run through the same normalisation the write path's allowlist
+	 * uses: an entry naming no field is dropped, `required` defaults to false,
+	 * and the published shape is `[{field, required}]` whatever the provider
+	 * spelled. What a client is told the transition accepts is therefore
+	 * exactly what the write path will accept.
+	 */
+	public function testInputsAreNormalisedThroughTheSharedContract(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider(
+			[
+				[
+					'action' => 'afhandelen',
+					'to' => 'afgehandeld',
+					'inputs' => [
+						['field' => 'motivering', 'required' => 1, 'label' => 'ignored'],
+						['field' => '', 'required' => true],
+						['required' => true],
+						'not-an-array',
+						['field' => 'bijlage'],
+					],
+				],
+			]
+		);
+
+		$actions = $this->engine->availableActions(self::CASE);
+
+		$this->assertSame(
+			[
+				['field' => 'motivering', 'required' => true],
+				['field' => 'bijlage', 'required' => false],
+			],
+			$actions[0]['inputs']
+		);
+	}//end testInputsAreNormalisedThroughTheSharedContract()
+
+	/**
+	 * A `blocked` entry keeps both the flag and the reason: the widget draws
+	 * the step and says why it cannot be taken, which is different from the
+	 * step not being offered at all.
+	 */
+	public function testBlockedEntryKeepsItsReason(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider(
+			[
+				[
+					'action' => 'afhandelen',
+					'to' => 'afgehandeld',
+					'blocked' => true,
+					'description' => 'Er ontbreekt nog een besluit.',
+				],
+			]
+		);
+
+		$actions = $this->engine->availableActions(self::CASE);
+
+		$this->assertTrue($actions[0]['blocked']);
+		$this->assertSame('Er ontbreekt nog een besluit.', $actions[0]['description']);
+	}//end testBlockedEntryKeepsItsReason()
+
+	/**
+	 * Static transitions win over a provider, exactly as they win over a
+	 * graph block, and the provider is not even resolved. A schema that grows
+	 * a second mode therefore never silently loses the transitions it had.
+	 */
+	public function testStaticTransitionsTakePrecedenceOverProvider(): void {
+		$this->registry->expects($this->never())->method('resolve');
+
+		$annotation = $this->providerAnnotation();
+		$annotation['transitions'] = [
+			'goedkeuren' => ['from' => ['in-behandeling'], 'to' => 'afgehandeld'],
+		];
+		$this->wire($this->caseObject(), $annotation);
+
+		$actions = $this->engine->availableActions(self::CASE);
+
+		$this->assertCount(1, $actions);
+		$this->assertSame('goedkeuren', $actions[0]['action']);
+	}//end testStaticTransitionsTakePrecedenceOverProvider()
+
+	/**
+	 * Between the two delegating modes the provider is read first, and the
+	 * graph's sibling fetch never happens. Note this ordering is unreachable
+	 * for a schema that saved cleanly: LifecycleAnnotationValidator refuses
+	 * `provider` beside `graph`. It is pinned here so the engine's behaviour
+	 * on an annotation that predates that rule is stated rather than assumed.
+	 */
+	public function testProviderIsReadBeforeGraph(): void {
+		$this->objectService->expects($this->never())->method('findAll');
+
+		$annotation = $this->providerAnnotation();
+		$annotation['graph'] = [
+			'schema' => 'statustype',
+			'parentField' => 'caseType',
+			'parentFrom' => 'caseType',
+			'orderField' => 'order',
+			'finalField' => 'isFinal',
+			'allowedMoves' => 'forward',
+		];
+		$this->wire($this->caseObject(), $annotation);
+		$this->provider([['action' => 'afhandelen', 'to' => 'afgehandeld']]);
+
+		$actions = $this->engine->availableActions(self::CASE);
+
+		$this->assertCount(1, $actions);
+		$this->assertSame('afhandelen', $actions[0]['action']);
+	}//end testProviderIsReadBeforeGraph()
+
+	/**
+	 * FAIL CLOSED: a provider tag nothing answers to throws, and does NOT
+	 * come back as an empty action list. An empty list is a legitimate answer
+	 * meaning "no moves from here", so a silent failure would be
+	 * indistinguishable from one and would render as a dead timeline.
+	 *
+	 * Drives a REAL registry against empty containers, so the fail-closed
+	 * policy is exercised rather than restated by a double.
+	 */
+	public function testUnregisteredProviderFailsClosed(): void {
+		$notFound = new class extends \Exception implements NotFoundExceptionInterface {
+		};
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException($notFound);
+		$serverContainer = $this->createMock(\OCP\IServerContainer::class);
+		$serverContainer->method('get')->willThrowException($notFound);
+
+		$permission = $this->createMock(PermissionHandler::class);
+		$permission->method('hasPermission')->willReturn(true);
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')
+			->willReturnCallback(
+				static function (string $app, string $key, string $default = '') {
+					return $default;
+				}
+			);
+
+		$engine = new TransitionEngine(
+			$this->objectService,
+			$this->schemaMapper,
+			$this->createMock(IEventDispatcher::class),
+			$this->createMock(IUserSession::class),
+			$permission,
+			$this->createMock(RegisterMapper::class),
+			$appConfig,
+			$this->logger,
+			new LifecycleWriteBoundary(new LifecycleActionContext()),
+			new LifecycleActionProviderRegistry($container, $serverContainer, $this->logger)
+		);
+
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('is not registered');
+
+		$engine->availableActions(self::CASE);
+	}//end testUnregisteredProviderFailsClosed()
+
+	/**
+	 * FAIL CLOSED, second route: the provider resolves but throws while
+	 * answering. Wrapped, logged, and never flattened into an empty list.
+	 */
+	public function testProviderThrowingIsWrappedNotSwallowed(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+
+		$provider = $this->createMock(LifecycleActionProviderInterface::class);
+		$provider->method('availableActions')
+			->willThrowException(new \LogicException('workflowTemplate is not valid JSON'));
+		$this->registry->method('resolve')->with(self::TAG)->willReturn($provider);
+
+		$this->logger->expects($this->once())->method('error');
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('could not list available actions');
+
+		$this->engine->availableActions(self::CASE);
+	}//end testProviderThrowingIsWrappedNotSwallowed()
+
+	/**
+	 * A provider that genuinely has no moves answers an empty list, and that
+	 * is a SUCCESS, not a failure. The pair with the two fail-closed cases
+	 * above: they are what makes an empty list readable as a real answer.
+	 */
+	public function testAProviderWithNoMovesAnswersAnEmptyList(): void {
+		$this->wire($this->caseObject('afgehandeld'), $this->providerAnnotation());
+		$this->provider([]);
+
+		$this->assertSame([], $this->engine->availableActions(self::CASE));
+	}//end testAProviderWithNoMovesAnswersAnEmptyList()
+}//end class

--- a/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineSlugContractTest.php
@@ -116,7 +116,8 @@ class TransitionEngineSlugContractTest extends TestCase {
 			$this->createMock(\Psr\Log\LoggerInterface::class),
 			new \OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary(
 				new \OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext()
-			)
+			),
+			$this->createMock(\OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry::class)
 		);
 
 	}//end engine()


### PR DESCRIPTION
## What was broken

`GET /apps/openregister/api/objects/{id}/available-actions` answers `{"actions": []}` for a dossiq case, so the `stages` widget that `@conduction/nextcloud-vue` ships would render a dead timeline on the page it was built for.

The reason, checked rather than assumed: dossiq's `case` schema declares no `x-openregister-lifecycle` block, so `TransitionEngine::availableActions()` returns before reading anything. dossiq's transitions live on a `workflowTemplate` object as a JSON encoded string, selected per case (a pinned `case.workflowTemplate`, otherwise the caseType's active template), with guards written in three spellings that are normalised on read.

## Why delegation

That is app policy, not schema. Teaching OpenRegister to read a workflow template would put one app's data model inside the foundation, and the next app with a different model would need a fourth. OpenRegister already delegates the two other app owned parts of a lifecycle: guards via `LifecycleGuardInterface` and actions via `LifecycleActionInterface`, both resolved from a DI tag named in the annotation. Provider mode is the same shape applied to the question "what can this object do right now".

An annotation now reads:

```json
"x-openregister-lifecycle": {
  "field": "status",
  "initial": { "from": "caseType", "field": "initialStatus" },
  "provider": "OCA\\Dossiq\\Lifecycle\\CaseActionProvider"
}
```

## What changed

`lib/Lifecycle/LifecycleActionProviderInterface.php` is the public contract an app implements. One method, `availableActions(array $object, string $userId): array`, documented read only in the style of the guard interface, because it is called on a GET the caller may repeat at will.

`lib/Service/Lifecycle/LifecycleActionProviderRegistry.php` resolves the tag: OpenRegister's container first, then the injected `IServerContainer` for an FQCN another app owns, with a per request instance cache. It fails closed. That matters more here than for guards: a registry that answered null would have to be reported as an empty action list, and an empty list is a legitimate answer meaning "no moves from here".

`lib/Service/Lifecycle/TransitionEngine.php` gains the provider branch, placed after the static map and before the graph block. Static transitions still win wherever both are declared, which `TransitionEngineGraphTest::testStaticTransitionsTakePrecedenceOverGraph` already pinned and still does. Whatever the provider returns is republished through the existing `publishedInputs()`, the same normalisation the write path's allowlist uses, so what a client is told a transition accepts is exactly what the write path will accept.

`lib/Service/Lifecycle/LifecycleAnnotationValidator.php` gains `validateProviderMode()` beside `validateGraphMode()`: `provider` must be a non-empty string, `field` must exist in `properties`, the enum requirement is relaxed as it is for graph mode because the app owns the state vocabulary, and declaring `transitions` or `graph` alongside `provider` is refused. The engine does settle that by precedence, but the mode it drops would read as declared and never run, which is the failure the graph `condition` refusal already guards against. An empty `transitions` or `graph` value declares no second mode and is not refused.

`lib/Db/SchemaMapper.php` adds `lifecycle-provider-invalid` and `lifecycle-provider-mode-conflict` to the blocking list. Most lifecycle findings there are advisory and stored as written, so a partial annotation does not break a register import. A broken provider declaration is the wrong shape for that policy: it fails on a GET, in front of a user, long after the author was told the save succeeded.

`lib/Controller/TransitionController.php` catches `LifecycleProviderException` before the `RuntimeException` branch it extends and answers 502. It must never collapse into `{actions: []}`: the widget reads 404 as "no lifecycle" and anything else as "could not read", and an empty list is a success meaning "no moves from here". The existing 403 and 404 paths are untouched.

`lib/Exception/LifecycleProviderException.php` is the distinct type that lets the controller tell a provider failure from a missing object. It extends `RuntimeException`, so every existing catch site behaves as it did.

`openspec/specs/object-lifecycle/spec.md` documents the three requirements, since the new methods carry `@spec` tags pointing at that capability.

## Verification

Baseline before any change, so inherited red is separable from new red: `php vendor/bin/phpunit tests/Unit/Service/Lifecycle/ tests/Unit/Controller/TransitionControllerTest.php` was 161 tests, 323 assertions, OK. Note the exit code is 1 even when green, because PHPUnit reports "No code coverage driver available" as a runner warning; the same is true of every run below.

After: 196 tests, 389 assertions, OK across `tests/Unit/Service/Lifecycle/`, `tests/Unit/Controller/TransitionControllerTest.php` and `tests/Unit/Db/SchemaMapperLifecycleConditionTest.php`. Twenty four new tests.

`COMPOSER_PROCESS_TIMEOUT=0 composer check:strict` exits **1**, and the exit code is misleading, so here is every leg of it:

| Leg | Result |
| --- | --- |
| lint | clean, no syntax errors |
| check:migration-version | no migrations added, nothing to check |
| phpcs | 74 files, clean |
| phpmd | clean, no findings |
| psalm | No errors found, 605s |
| phpstan | OK, no errors, 1766 files |
| test:all | 20053 tests, 49162 assertions, 24 skipped, **zero failures and zero errors** |

The 1 comes entirely from PHPUnit, which exits non-zero because it reports "No code coverage driver available" as a runner warning. That is the only non-green line in the whole run: grepping the `test:all` section for `FAILURES`, `ERRORS`, `Failures:`, `Errors:` or a numbered failure returns exactly one match, and that match is the coverage-driver warning. The same is true of the pre-change baseline, which also exits 1 while green.

### Mutations

Every new guard was mutation checked: the behaviour was broken, the intended assertion was watched to redden at exit 1, the source was restored, and `git diff` on the source was confirmed empty afterwards.

| Mutation | Assertion that reddened |
| --- | --- |
| Engine: delete the provider branch from `availableActions()` | 8 failures in `TransitionEngineProviderTest`, led by `testProviderActionsArePublished` |
| Engine: consult the provider even when a static map is declared (`if ($transitions === [])` to `if (true)`) | `TransitionEngineGraphTest::testStaticTransitionsTakePrecedenceOverGraph` and `TransitionEngineProviderTest::testStaticTransitionsTakePrecedenceOverProvider` |
| Engine: publish the provider's raw `inputs` instead of running them through `publishedInputs()` | `testInputsAreNormalisedThroughTheSharedContract` |
| Engine: return `[]` instead of throwing when the provider throws | `testProviderThrowingIsWrappedNotSwallowed` |
| Engine: drop the `blocked` carry through | `testBlockedEntryKeepsItsReason` |
| Registry: remove the `instanceof` guard | `LifecycleActionProviderRegistryTest::testWrongTypeFailsClosed` |
| Registry: remove the per request cache | `testResolutionIsCachedPerRequest` (error, container called twice) |
| Validator: remove the provider dispatch in `validate()` | 10 failures across `LifecycleAnnotationValidatorTest` and `SchemaMapperLifecycleConditionTest` |
| Validator: drop only the two modes conflict rule | `testProviderBesideTransitionsIsRejected`, `testProviderBesideGraphIsRejected`, `testTwoModesOnOneFieldRefuseTheSave` |
| SchemaMapper: remove the two provider codes from the blocking list | `testAnEmptyProviderRefusesTheSave`, `testTwoModesOnOneFieldRefuseTheSave` |
| Controller: remove the `LifecycleProviderException` catch | the new 502 test, with the 403 and 404 tests still green |

The fail closed case is also covered without a double: `testUnregisteredProviderFailsClosed` drives a real `LifecycleActionProviderRegistry` against empty containers, so the policy is exercised rather than restated by a mock.

The hydra gates were also run scoped to this diff (`HYDRA_GATE_BASE_REF=origin/development ... --scope-to-diff`): one gate fails, `gate-67 openregister-contract-parity`, on `lib/Contract/ObjectServiceInterface.php`, `RegisterSlugResolution.php` and `RegisterSlugResolverInterface.php`. This change touches no file under `lib/Contract/`, so that failure is inherited and pre-existing. Every other gate passed or was correctly scoped out.

## Notes

PHPMD reported two new findings on `TransitionEngine` that the tenth constructor parameter and the provider methods caused: `ExcessiveParameterList` and `ExcessiveClassLength`. Neither was in `phpmd.baseline.xml`, and both were confirmed absent before this change. They carry `@SuppressWarnings` with written reasons in the file, which is this codebase's own idiom for both rules; the baseline was not grown. If `TransitionEngine` grows again, graph mode derivation is the block to extract.

Psalm reports no errors project wide. Findings that appear when single files are analysed in isolation (`RedundantPropertyInitializationCheck` in `lib/Db/MultiTenancyTrait.php`, and PHPStan calling `SchemaMapper::$userSession` and `$groupManager` never read at lines 188 and 197) are artefacts of the narrowed scope and do not appear in the project wide run. This change's `SchemaMapper` hunks are at lines 1183 and 1203 in any case, so they sit on no line it touches.
