### PR TITLE
fix(archival): an unknown key in x-openregister-archival warns, it does not refuse the schema

### DIFF
--- a/lib/Db/SchemaMapper.php
+++ b/lib/Db/SchemaMapper.php
@@ -1546,12 +1546,31 @@ class SchemaMapper extends QBMapper {
 
 		$shape = ['x-openregister-archival' => $annotation];
 
-		$errors = (new ArchivalAnnotationValidator())->validate(schema: $shape);
-		if (count($errors) === 0) {
+		$findings = (new ArchivalAnnotationValidator())->validate(schema: $shape);
+		$split = ArchivalAnnotationValidator::partition(findings: $findings);
+
+		// An UNKNOWN key is surfaced and ignored, never fatal — the same rule
+		// R07 applies to an unknown `x-openregister-*` key one level up
+		// (logDroppedAnnotationKeys). It declares nothing, so dropping it loses
+		// nothing, whereas refusing it refuses the whole schema: at import time
+		// that costs the register every object of that schema, and the operator
+		// sees it as a seeding failure several layers away from the annotation.
+		if (count($split['warnings']) > 0) {
+			$this->logger->warning(
+				sprintf(
+					'[OpenRegister.SchemaMapper] Ignored %d unknown x-openregister-archival key(s) on schema "%s": %s',
+					count($split['warnings']),
+					(string)($schema->getSlug() ?? ''),
+					implode(' ', array_map(static fn (array $finding) => $finding['message'], $split['warnings']))
+				)
+			);
+		}
+
+		if (count($split['errors']) === 0) {
 			return;
 		}
 
-		$messages = array_map(static fn (array $err) => $err['message'], $errors);
+		$messages = array_map(static fn (array $err) => $err['message'], $split['errors']);
 		throw new Exception('x-openregister-archival: ' . implode(' ', $messages));
 	}//end validateArchivalAnnotation()
 

--- a/lib/Service/Archival/ArchivalAnnotationValidator.php
+++ b/lib/Service/Archival/ArchivalAnnotationValidator.php
@@ -78,6 +78,51 @@ final class ArchivalAnnotationValidator {
 	private const ALLOWED_RULE_KEYS = ['condition', 'retention', 'reason'];
 
 	/**
+	 * Severity marking a finding that SHALL NOT refuse the schema.
+	 *
+	 * A finding without a `severity` key is an error, so every existing check
+	 * keeps refusing exactly what it refused before this constant existed.
+	 *
+	 * @var string
+	 */
+	public const SEVERITY_WARNING = 'warning';
+
+	/**
+	 * Split validator findings into the ones that refuse a schema and the ones
+	 * that only deserve a log line.
+	 *
+	 * Callers save the schema when `errors` is empty, whatever `warnings`
+	 * holds. Kept here rather than at each call site so "which findings are
+	 * fatal" is answered in the file that decides it.
+	 *
+	 * @param array<int, array{code: string, message: string, severity?: string}> $findings Findings from validate().
+	 *
+	 * @return array{
+	 *     errors: array<int, array{code: string, message: string, severity?: string}>,
+	 *     warnings: array<int, array{code: string, message: string, severity?: string}>
+	 * }
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	public static function partition(array $findings): array {
+		$errors = [];
+		$warnings = [];
+		foreach ($findings as $finding) {
+			if (($finding['severity'] ?? '') === self::SEVERITY_WARNING) {
+				$warnings[] = $finding;
+				continue;
+			}
+
+			$errors[] = $finding;
+		}
+
+		return [
+			'errors' => $errors,
+			'warnings' => $warnings,
+		];
+	}//end partition()
+
+	/**
 	 * Validate the `x-openregister-archival` annotation block on a schema definition.
 	 *
 	 * @param array<string, mixed> $schema Full schema definition. The validator only
@@ -87,7 +132,9 @@ final class ArchivalAnnotationValidator {
 	 *                                     save time (fields are resolved by the
 	 *                                     runtime evaluator against actual rows).
 	 *
-	 * @return array<int, array{code: string, message: string}> List of errors (empty = valid).
+	 * @return array<int, array{code: string, message: string, severity?: string}> List of findings
+	 *         (empty = valid). A finding carrying `severity: warning` does NOT refuse the schema;
+	 *         see {@see partition()} and {@see SEVERITY_WARNING}.
 	 *
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
@@ -166,22 +213,7 @@ final class ArchivalAnnotationValidator {
 			}
 		}
 
-		// Reject unknown keys at the top level, for the same reason as under
-		// `retention`: a typo that is silently ignored declares nothing, and an
-		// export that omits the fact looks identical to a schema that never
-		// declared it.
-		foreach (array_keys($annotation) as $key) {
-			if (in_array((string)$key, self::ALLOWED_ANNOTATION_KEYS, true) === false) {
-				$errors[] = [
-					'code' => 'archival-unknown-key',
-					'message' => sprintf(
-						'x-openregister-archival contains unknown key "%s". Allowed: %s.',
-						(string)$key,
-						implode(', ', self::ALLOWED_ANNOTATION_KEYS)
-					),
-				];
-			}
-		}
+		$errors = array_merge($errors, $this->unknownTopLevelKeys(annotation: $annotation));
 
 		$facts = new ArchivalFactsValidator();
 
@@ -196,6 +228,60 @@ final class ArchivalAnnotationValidator {
 
 
 
+
+	/**
+	 * Report keys at the top level of the annotation that are not on the
+	 * allow-list, as WARNINGS rather than errors.
+	 *
+	 * That severity is the whole point of this method. An unknown key here is
+	 * an EXTRA key beside a `retention` block that is itself valid: it declares
+	 * nothing, so ignoring it loses nothing. Refusing it refuses the SCHEMA, and
+	 * at import time `ImportHandler` then drops that schema and every object
+	 * that needed it, which is a total loss of the register for a stray key.
+	 *
+	 * Measured on 2026-09-12: shipping this check as an error took filinq (9 of
+	 * 22 schemas, on `category` / `action` / `responsibleParty`) and pipelinq
+	 * (the `ticket` supertype, on a `_note`) red within the hour, on payloads
+	 * those apps had carried for weeks, because every app clones
+	 * openregister@development at CI run time. The first symptom was an HTTP 412
+	 * out of each app's own demo-data seeding, four layers away from this check.
+	 *
+	 * It matches the rule the enclosing level already follows: R07 DROPS an
+	 * unknown `x-openregister-*` key and warns
+	 * ({@see \OCA\OpenRegister\Db\SchemaMapper::logDroppedAnnotationKeys}). A key
+	 * one level further in should not be stricter than the key containing it.
+	 *
+	 * Every check that validates a fact the schema actually DECLARED stays an
+	 * error: a malformed ISO-8601 retention, an unknown key INSIDE a block, a
+	 * term outside MDTO's begrippenlijst, a literal date where a property name
+	 * belongs.
+	 *
+	 * @param array<string, mixed> $annotation The `x-openregister-archival` block.
+	 *
+	 * @return array<int, array{code: string, message: string, severity: string}>
+	 *
+	 * @spec openspec/specs/archival-annotation-vocabulary/spec.md
+	 */
+	private function unknownTopLevelKeys(array $annotation): array {
+		$warnings = [];
+		foreach (array_keys($annotation) as $key) {
+			if (in_array((string)$key, self::ALLOWED_ANNOTATION_KEYS, true) === true) {
+				continue;
+			}
+
+			$warnings[] = [
+				'code' => 'archival-unknown-key',
+				'severity' => self::SEVERITY_WARNING,
+				'message' => sprintf(
+					'x-openregister-archival contains unknown key "%s". Allowed: %s.',
+					(string)$key,
+					implode(', ', self::ALLOWED_ANNOTATION_KEYS)
+				),
+			];
+		}
+
+		return $warnings;
+	}//end unknownTopLevelKeys()
 
 	/**
 	 * Validate a single rule entry.

--- a/openspec/specs/archival-annotation-vocabulary/spec.md
+++ b/openspec/specs/archival-annotation-vocabulary/spec.md
@@ -52,6 +52,14 @@ The platform SHALL ship an `OCA\OpenRegister\Service\Archival\ArchivalAnnotation
 - **WHEN** the schema is saved
 - **THEN** `SchemaMapper::insert()` SHALL throw an `\Exception` whose message contains `archival-retention-unknown-key` and mentions `strategy`
 
+#### Scenario: Unknown key at the top level is reported, not rejected
+- @e2e exclude schema-save validation — covered by PHPUnit
+- **GIVEN** a schema declares `x-openregister-archival = { retention: { default: "P7Y" }, category: "Archiefwet 1995 selectielijst", action: "destroy" }`
+- **WHEN** the schema is saved
+- **THEN** the save SHALL succeed
+- **AND** `SchemaMapper` SHALL log one warning naming the schema and every ignored key
+- **AND** the import of a register declaring that schema SHALL link it, not drop it
+
 #### Scenario: Well-formed annotation passes
 - **GIVEN** a schema declares `x-openregister-archival.retention = { default: "P30D", rules: [{ condition: "statusCode < 400", retention: "PT1H", reason: "successful integrations" }] }`
 - **WHEN** the schema is saved
@@ -313,9 +321,21 @@ A fact no source establishes SHALL be ABSENT from `_retention` and from the
 export: no placeholder, and identical on create and on read, which is the rule
 `UnestablishedValues` applies to the rest of the block.
 
-Validation at schema save SHALL refuse an unknown key, at the top level and
-inside each block, as unknown `retention` keys already are. It SHALL also
-refuse a term outside the MDTO begrippenlijst the element cites:
+Validation at schema save SHALL REPORT an unknown key at the top level of
+`x-openregister-archival` and SHALL NOT refuse the schema for one: the key
+declares nothing, so ignoring it loses nothing, while refusing it costs the
+whole schema and, at import, every object that needed it. This is the rule R07
+already applies to an unknown `x-openregister-*` key one level up, which is
+dropped with a warning rather than refused; a key inside the annotation SHALL
+NOT be stricter than the key that contains it.
+
+Unknown keys inside each BLOCK (`retention`, `useRestriction`,
+`temporalCoverage`) SHALL still refuse the schema, as they already did: those
+sit beside a fact the schema is actually declaring, where a typo changes the
+meaning of a declaration rather than adding an inert one.
+
+Validation SHALL also refuse a term outside the MDTO begrippenlijst the element
+cites:
 `Aggregatieniveaus` for `aggregationLevel` and `BeperkingGebruikTypeLijst` for
 `useRestriction.type`. Both lists are formally OPEN, so this is stricter than
 MDTO, and deliberately: the exported element names the list it took the term

--- a/tests/Unit/Service/Archival/ArchivalAnnotationValidatorTest.php
+++ b/tests/Unit/Service/Archival/ArchivalAnnotationValidatorTest.php
@@ -74,8 +74,8 @@ final class ArchivalAnnotationValidatorTest extends TestCase {
 		self::assertSame([], $errors);
 	}//end testDeclaredArchivalFactsPass()
 
-	public function testUnknownTopLevelKeyIsRejected(): void {
-		$errors = $this->validator->validate(
+	public function testUnknownTopLevelKeyIsReportedAsAWarningNotAnError(): void {
+		$findings = $this->validator->validate(
 			[
 				'x-openregister-archival' => [
 					'retention' => ['default' => 'P30D'],
@@ -84,8 +84,91 @@ final class ArchivalAnnotationValidatorTest extends TestCase {
 			]
 		);
 
-		self::assertSame(['archival-unknown-key'], array_column($errors, 'code'));
-	}//end testUnknownTopLevelKeyIsRejected()
+		self::assertSame(['archival-unknown-key'], array_column($findings, 'code'));
+
+		// The finding is still made — a typo is still surfaced — but it is a
+		// warning, so the schema is saved rather than refused.
+		$split = ArchivalAnnotationValidator::partition(findings: $findings);
+		self::assertSame([], $split['errors'], 'An unknown top-level key must not refuse the schema.');
+		self::assertCount(1, $split['warnings']);
+		self::assertSame(
+			ArchivalAnnotationValidator::SEVERITY_WARNING,
+			$findings[0]['severity'] ?? null
+		);
+	}//end testUnknownTopLevelKeyIsReportedAsAWarningNotAnError()
+
+	/**
+	 * REGRESSION, 2026-09-12. openregister#3661 made an unknown top-level key
+	 * refuse the schema. `ImportHandler` then drops a refused schema and every
+	 * object that needed it, so two apps went red on payloads they had carried
+	 * for weeks, each surfacing as an HTTP 412 from their own demo-data seeding
+	 * rather than as anything naming this annotation:
+	 *
+	 *   filinq   — 9 of 22 schemas, on `category` / `action` / `responsibleParty`
+	 *   pipelinq — the `ticket` supertype, on a `_note`
+	 *
+	 * Both payloads are reproduced verbatim here. Every app clones
+	 * openregister@development at CI run time, so a check that refuses one of
+	 * these reaches all 21 apps the minute it merges.
+	 *
+	 * @return void
+	 */
+	public function testExtraDescriptiveKeysBesideAValidRetentionBlockDoNotRefuseTheSchema(): void {
+		$filinq = $this->validator->validate(
+			[
+				'x-openregister-archival' => [
+					'retention' => ['default' => 'P7Y'],
+					'category' => 'Archiefwet 1995 selectielijst — cat. 3.2: zakelijke correspondentie',
+					'action' => 'destroy',
+					'responsibleParty' => 'docudesk-privacy-officer',
+				],
+			]
+		);
+		self::assertSame(
+			[],
+			ArchivalAnnotationValidator::partition(findings: $filinq)['errors'],
+			"filinq's correspondence schema must still import."
+		);
+		self::assertCount(3, ArchivalAnnotationValidator::partition(findings: $filinq)['warnings']);
+
+		$pipelinq = $this->validator->validate(
+			[
+				'x-openregister-archival' => [
+					'_note' => 'unify-ticket-supertype: the retired contactmoment schema carried a VNG/AVG policy.',
+					'retention' => ['default' => 'P2Y'],
+				],
+			]
+		);
+		self::assertSame(
+			[],
+			ArchivalAnnotationValidator::partition(findings: $pipelinq)['errors'],
+			"pipelinq's ticket supertype must still import."
+		);
+	}//end testExtraDescriptiveKeysBesideAValidRetentionBlockDoNotRefuseTheSchema()
+
+	/**
+	 * The other half of the rule: loosening the UNKNOWN-key check must not
+	 * loosen the checks on a fact the schema actually declared. Each of these
+	 * validates something present, so each stays fatal.
+	 *
+	 * @return void
+	 */
+	public function testDeclaredFactsAreStillRefusedWhenMalformed(): void {
+		$cases = [
+			'malformed retention' => ['retention' => ['default' => 'seven years']],
+			'unknown retention key' => ['retention' => ['default' => 'P30D', 'strategy' => 'destroy']],
+			'term off the begrippenlijst' => ['retention' => ['default' => 'P30D'], 'aggregationLevel' => 'Bananen'],
+		];
+
+		foreach ($cases as $label => $annotation) {
+			$findings = $this->validator->validate(['x-openregister-archival' => $annotation]);
+			self::assertNotSame(
+				[],
+				ArchivalAnnotationValidator::partition(findings: $findings)['errors'],
+				sprintf('%s must still refuse the schema.', $label)
+			);
+		}
+	}//end testDeclaredFactsAreStillRefusedWhenMalformed()
 
 	public function testAggregationLevelOutsideTheListIsRejected(): void {
 		$errors = $this->validator->validate(


### PR DESCRIPTION
## What broke

Demo-data seeding started failing on **filinq** and **pipelinq** on 2026-09-12, blocking their E2E (Playwright) and Newman suites. Both surfaced as:

```
FAILED STEP: Seed test data
##[error]Demo-data seeding failed (HTTP 412).
```

The 412 comes from each app's own `SetupController`, not from OpenRegister. It is correct behaviour: the app refuses to seed because its schemas are not provisioned. The reason they were not provisioned is here.

## Where the 412 actually comes from

The chain, read from pipelinq's job log rather than inferred:

1. `POST /apps/pipelinq/api/settings/reimport` returns **HTTP 200**, and its body shows `"ticket_schema": ""`. The schema resolved to nothing.
2. The Nextcloud log for that same request carries:
   ```
   [ImportHandler] Failed to import schema: x-openregister-archival: x-openregister-archival
   contains unknown key "_note". Allowed: retention, aggregationLevel, useRestriction, temporalCoverage.
   [ImportHandler] Failed to create schema (Pass 1)   schemaKey: ticket
   [ImportHandler] PARTIAL IMPORT: 1 of 114 schema(s) were rejected and are NOT linked to
   any register in this import: ticket.
   ```
3. `POST /apps/pipelinq/api/setup/action/seed-demo-data` then returns **412** with `Pipelinq register or schemas are not provisioned`.

filinq is the same mechanism at nine times the scale: **9 of 22 schemas rejected** on `category`, `action`, `responsibleParty`.

## The cause

`ArchivalAnnotationValidator` gained a **top-level** allow-list in #3661. `SchemaMapper::insert()/update()` turns any finding into a thrown exception, and `ImportHandler` turns a schema that will not save into a schema that is dropped along with every object that needed it.

The annotation is optional, and an unknown key beside a valid `retention` block declares nothing, so ignoring it loses nothing, while refusing it costs the whole schema.

Evidence that #3661 is the cause and not merely coincident:

- `ALLOWED_ANNOTATION_KEYS` and the `archival-unknown-key` code do not exist at `a2b7b959a^`; `git grep` finds 0 occurrences before, and the failing log text is that check's `sprintf` verbatim.
- The `retention` unknown-key check DID exist before. Only the top level is new.
- Both apps' payloads are unchanged for weeks; only the validator moved.

## The fix

An unknown key at the **top level** of `x-openregister-archival` is now a **warning**: reported through `SchemaMapper`'s logger, ignored, and the schema saves.

This is the rule OpenRegister already applies one level up. **R07** (`SchemaMapper::logDroppedAnnotationKeys`) DROPS an unknown `x-openregister-*` key and warns. A key *inside* the annotation should not be stricter than the key that contains it.

Everything that validates a fact the schema actually **declared** stays fatal:

- malformed ISO-8601 `retention.default`
- unknown keys inside `retention`, `useRestriction`, `temporalCoverage`
- a term outside MDTO's begrippenlijst

Those sit beside a real declaration, where a typo changes a meaning rather than adding an inert key.

## Regression test

`ArchivalAnnotationValidatorTest` gains both apps' payloads verbatim, plus a test that the declared-fact checks are still fatal.

**Mutation-checked, so the test cannot be one that merely passes:** removing the single `severity` line reproduces the regression: 2 failures, exit 1. Restored: 20 passed, 29 assertions.

## Measured against the apps' real payloads

Both apps' shipped `lib/Settings/*.json` were run through the validator directly, before and after:

| Validator | Blocks scanned | Would refuse the schema | Warn only |
|---|---|---|---|
| `origin/development` (with #3661) | 20 | **19** | 0 |
| this branch | 20 | **0** | 19 |

19 is also the count an independent fleet sweep found by parsing the JSON, so two methods agree.

## Blast radius

This is the foundation repo and every app clones `openregister@development` at CI run time, which is exactly why #3661 reached the fleet within the hour. This change only ever turns a refusal into a save, so it cannot newly refuse anything.

Fleet sweep of all 21 core apps for offending `x-openregister-archival` keys:

| App | Offending blocks |
|---|---|
| filinq | 18 (9 schemas × 2 files) |
| pipelinq | 1 |
| integriq, dossiq | 0 (ship valid annotations) |
| the other 17 | ship no `x-openregister-archival` |

So filinq and pipelinq are the whole affected set, which matches CI exactly: they are the only two core apps whose latest `development` run fails at `Seed test data`.

## Verified

`COMPOSER_PROCESS_TIMEOUT=0 composer check:strict`, one run, per stage:

| Stage | Verdict |
|---|---|
| lint | passed |
| check:migration-version | passed |
| phpcs | passed |
| phpmd | see note below |
| psalm | `No errors found!` |
| phpstan | `[OK] No errors` |
| test:all | **20,104 tests, 49,274 assertions, 0 failures, 0 errors** |

Two stages exit non-zero for reasons that are not this change, and both were run to ground rather than waved past:

- **test:all** exits 1 on `No code coverage driver available`. No xdebug or pcov on this box. PHPUnit's own verdict line is `OK, but there were issues!` with 1 warning and 0 failures.
- **phpmd** reported `validate() has 124 lines` at a line where the method is 83 lines long. That is a stale `~/.pdepend` parse cache, currently 14 GB on this machine. With a clean cache (`HOME` redirected to an empty dir) phpmd on `lib` exits 0, and phpmd on the file alone exits 0 either way. CI has no such cache.

Also run directly:

- `vendor/bin/phpunit tests/Unit/Service/Archival`: **OK (122 tests, 272 assertions)**, exit 0
- mutation check: exit 1 without the fix, exit 0 with it

## Inherited, reported not fixed

`phpcs` reports **71 pre-existing** `@spec`-tag warnings on untouched lines of `lib/Db/SchemaMapper.php`. Not this PR's.

## Follow-up, not blocking

filinq's `category` / `action` / `responsibleParty` carry real selectielijst meaning (including several literal `"TODO: confirm ... with selectielijst manager"` values) with no home in the current vocabulary, so they need a destination decision rather than deletion. They are harmless warnings after this change. pipelinq's `_note` is a documentation convention used 9× across its configs; worth deciding separately whether `_`-prefixed keys should be silent rather than warned, so the warning channel does not train people to ignore it.

Refs: #3661

🤖 Generated with [Claude Code](https://claude.com/claude-code)