### PR TITLE
feat(e2e): refuse the shared instance unless the run names it

### DIFF
--- a/playwright.flow.config.ts
+++ b/playwright.flow.config.ts
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: EUPL-1.2
  */
 import { defineConfig } from '@playwright/test'
+import { resolveBaseUrl } from './tests/e2e/base-url.ts'
 
 export default defineConfig({
 	testDir: './tests/e2e/api-direct',
@@ -19,7 +20,12 @@ export default defineConfig({
 	reporter: [['list']],
 	timeout: 120_000,
 	use: {
-		baseURL: process.env.NEXTCLOUD_URL || 'http://localhost:8080',
+		// Routed through the shared resolver so this config is not a second
+		// entrance for the base URL. The `|| 'http://localhost:8080'` that
+		// stood here aimed at the shared dev instance whenever NEXTCLOUD_URL
+		// was unset, which is the accident tests/e2e/shared-instance.ts exists
+		// to refuse. NEXTCLOUD_URL is still accepted: the resolver reads it.
+		baseURL: resolveBaseUrl(),
 		httpCredentials: {
 			username: process.env.NEXTCLOUD_ADMIN_USER || 'admin',
 			password: process.env.NEXTCLOUD_ADMIN_PASSWORD || 'admin',

--- a/tests/e2e/base-url.ts
+++ b/tests/e2e/base-url.ts
@@ -30,10 +30,14 @@
  * every app in the fleet needs the identical resolver.
  */
 
+import { assertInstancePermitted } from './shared-instance.ts'
+
 /**
  * Resolve the base URL of the Nextcloud instance under test.
  *
- * @throws {Error} When none of the accepted environment variables is set.
+ * @throws {Error} When none of the accepted environment variables is set, or
+ * when the resolved URL is the shared development instance and the run did not
+ * name it in the opt-in variable.
  * @return {string} The base URL, without a trailing slash.
  */
 export function resolveBaseUrl(): string {
@@ -51,7 +55,9 @@ export function resolveBaseUrl(): string {
 		)
 	}
 
-	return url.replace(/\/+$/, '')
+	// One place a target enters this suite, so one place the shared-instance
+	// opt-in is checked. See tests/e2e/shared-instance.ts.
+	return assertInstancePermitted(url.replace(/\/+$/, ''))
 }
 
 /** The shared dev container these suites run against by default. */

--- a/tests/e2e/shared-instance.ts
+++ b/tests/e2e/shared-instance.ts
@@ -287,11 +287,11 @@ export function refuseOnSharedInstance(
 	if (isSharedInstance(target) === false) return
 	throw new Error(
 		`[${APP_ID} e2e] ${what} must not run on ${target}.\n`
-		+ `${reason}\n`
-		+ `${SHARED_INSTANCE_FLAG} permits the suite on a shared instance. It does `
-		+ 'not permit this.\n'
-		+ 'Start a disposable rig and point the suite at that instead:\n\n'
-		+ '    PLAYWRIGHT_BASE_URL=http://localhost:8095 npx playwright test\n',
+			+ `${reason}\n`
+			+ `${SHARED_INSTANCE_FLAG} permits the suite on a shared instance. It does `
+			+ 'not permit this.\n'
+			+ 'Start a disposable rig and point the suite at that instead:\n\n'
+			+ '    PLAYWRIGHT_BASE_URL=http://localhost:8095 npx playwright test\n',
 	)
 }
 
@@ -318,7 +318,9 @@ export function occPrefix(env: NodeJS.ProcessEnv = process.env): string[] {
 	if (explicit !== '') return explicit.split(/\s+/).filter((p) => p !== '')
 
 	const container = (
-		env.OPENREGISTER_E2E_CONTAINER ?? env.NEXTCLOUD_CONTAINER ?? ''
+		env.OPENREGISTER_E2E_CONTAINER
+		?? env.NEXTCLOUD_CONTAINER
+		?? ''
 	).trim()
 	if (container !== '') {
 		return ['docker', 'exec', '-u', 'www-data', container, 'php', 'occ']

--- a/tests/e2e/shared-instance.ts
+++ b/tests/e2e/shared-instance.ts
@@ -1,0 +1,328 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Openregister Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Whether this e2e run is allowed to touch the instance it is aimed at.
+ *
+ * GENERATED FROM hydra/templates/e2e/shared-instance.ts.tmpl. The only thing
+ * that differs per app is `APP_ID` below. Edit the template, not the copies.
+ *
+ * The problem
+ * -----------
+ * Every Conduction dev box runs one shared Nextcloud on port 8080 (or 80 when
+ * it is published without a port). It bind-mounts the host checkouts under
+ * `apps-extra/`, so it serves whatever everybody on the box is editing, and it
+ * carries data colleagues are working on. An e2e suite seeds OpenRegister
+ * objects and then deletes them again. Pointed at that instance it is not
+ * running tests, it is editing someone else's environment. Two apps were
+ * caught doing exactly this, by default, because their base URL fell back to
+ * `http://localhost:8080` when nothing was set.
+ *
+ * The rule
+ * --------
+ * Aiming at a shared instance is allowed. Aiming at one BY ACCIDENT is not.
+ * So the target has to be named twice: once as the base URL, and once in an
+ * opt-in variable that holds the origin you permit.
+ *
+ *     E2E_ALLOW_SHARED_INSTANCE=http://localhost:8080 \
+ *     PLAYWRIGHT_BASE_URL=http://localhost:8080 \
+ *     npx playwright test
+ *
+ * The flag holds an ORIGIN, not `1`. A bare `1` left in a shell profile goes
+ * on permitting every shared instance the suite ever meets. An origin permits
+ * the one you typed and nothing else, so aiming somewhere new makes you type
+ * the new one.
+ *
+ * Two spellings are accepted and they mean the same thing:
+ *
+ *   E2E_ALLOW_SHARED_INSTANCE              fleet-wide, permits any app's suite
+ *   OPENREGISTER_E2E_ALLOW_SHARED_INSTANCE  this app only
+ *
+ * The app-specific spelling is the safer one to leave in a profile, because it
+ * stops at this app. The fleet-wide one is for a session that deliberately
+ * drives several suites at one instance.
+ *
+ * CI is exempt
+ * ------------
+ * On a GitHub runner `localhost:8080` is the runner's own throwaway Nextcloud,
+ * started by the shared ConductionNL/.github workflow and destroyed with the
+ * job. Nothing there is shared with anybody. Treating it as shared would break
+ * every e2e run in the fleet, so `isCI()` short-circuits the whole rule.
+ *
+ * This is one of three guards, and they do not overlap
+ * ---------------------------------------------------
+ *  1. An age bound on the cross-run residue sweep stops one session deleting
+ *     another session's LIVE fixtures.
+ *  2. A run ledger stops a run's own teardown reaching rows it never created,
+ *     at any age. Content matching (`JSON.stringify(row).includes(prefix)`) is
+ *     not ownership: it deletes anything that happens to carry the string.
+ *  3. This flag stops the cross-run sweep deleting anything at all on a shared
+ *     box, because there it cannot tell your leftovers from a colleague's.
+ *
+ * Guard 3 is the only portable one, which is why it is the one in this
+ * template. Guard 2 needs a single create funnel and is written per app.
+ */
+
+/** The app this copy belongs to. Substituted when the template is rendered. */
+export const APP_ID = 'openregister'
+
+/** The app-specific opt-in variable. Holds an origin, not a boolean. */
+export const SHARED_INSTANCE_FLAG = 'OPENREGISTER_E2E_ALLOW_SHARED_INSTANCE'
+
+/** The fleet-wide opt-in variable. Same contract, wider blast radius. */
+export const FLEET_INSTANCE_FLAG = 'E2E_ALLOW_SHARED_INSTANCE'
+
+/**
+ * Both spellings, app-specific first so it wins a disagreement.
+ */
+export const SHARED_INSTANCE_FLAGS = [
+	SHARED_INSTANCE_FLAG,
+	FLEET_INSTANCE_FLAG,
+] as const
+
+/**
+ * Origins that belong to the shared Conduction development stack.
+ *
+ * Port 8080 is the `nextcloud` container every dev box runs, and port 80 is
+ * the same stack published without a port. A disposable rig gets its own high
+ * port (8095, 8614, 8731 and so on), never matches this list, and needs no
+ * flag.
+ */
+const SHARED_PORTS = new Set(['80', '8080'])
+
+/** Loopback spellings that all name the same host. */
+const LOOPBACK = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0'])
+
+/** A URL split into the three things this module compares. */
+interface OriginParts {
+	/** `http:` or `https:`, including the colon. */
+	protocol: string
+	/** Hostname, with every loopback spelling folded onto `localhost`. */
+	host: string
+	/** Port as a string, with the protocol default made explicit. */
+	port: string
+}
+
+/**
+ * Split a URL into protocol, folded host and explicit port.
+ *
+ * The explicit port is the whole point. `new URL('http://127.0.0.1').port` is
+ * the empty string, not `80`, so a comparison against a port list silently
+ * misses every shared origin written without one. That is the failure this
+ * helper exists to make impossible, by being the only place a port is read.
+ *
+ * @param value A base URL.
+ * @return The parts, or null when the value will not parse.
+ */
+function splitOrigin(value: string): OriginParts | null {
+	let url: URL
+	try {
+		url = new URL(value)
+	} catch {
+		return null
+	}
+	return {
+		protocol: url.protocol,
+		host: LOOPBACK.has(url.hostname) ? 'localhost' : url.hostname,
+		port: url.port !== '' ? url.port : url.protocol === 'https:' ? '443' : '80',
+	}
+}
+
+/**
+ * Reduce a URL to `scheme://host:port`, with loopback spellings folded onto
+ * `localhost` and the default port made explicit.
+ *
+ * Returns the trimmed input when it will not parse, so a malformed value fails
+ * later on its own HTTP probe with a message about the real problem rather
+ * than here.
+ *
+ * @param value A base URL.
+ * @return The normalised origin.
+ */
+export function normaliseOrigin(value: string): string {
+	const parts = splitOrigin(value)
+	if (parts === null) return value.trim().replace(/\/+$/, '')
+	return `${parts.protocol}//${parts.host}:${parts.port}`
+}
+
+/**
+ * Whether this URL names an instance shared with other people.
+ *
+ * Shared means loopback on port 80 or 8080. A remote host is somebody's
+ * deployment and is out of scope here: this guard is about the box you are
+ * sitting at.
+ *
+ * @param value A base URL.
+ * @return True when the origin is the shared development stack.
+ */
+export function isSharedOrigin(value: string): boolean {
+	const parts = splitOrigin(value)
+	if (parts === null) return false
+	return parts.host === 'localhost' && SHARED_PORTS.has(parts.port)
+}
+
+/**
+ * Whether this process runs on a CI runner.
+ *
+ * @return True on GitHub Actions, or any CI that exports `CI`.
+ */
+export function isCI(): boolean {
+	return Boolean(process.env.CI) || Boolean(process.env.GITHUB_ACTIONS)
+}
+
+/**
+ * The flag value that permits this origin, if any flag does.
+ *
+ * @param target The base URL being aimed at.
+ * @param env    The environment to read.
+ * @return The variable name and its value, or null when none matches.
+ */
+export function permittingFlag(
+	target: string,
+	env: NodeJS.ProcessEnv = process.env,
+): { name: string; value: string } | null {
+	const wanted = normaliseOrigin(target)
+	for (const name of SHARED_INSTANCE_FLAGS) {
+		const value = (env[name] ?? '').trim()
+		if (value === '') continue
+		if (normaliseOrigin(value) === wanted) return { name, value }
+	}
+	return null
+}
+
+/**
+ * Whether this run deliberately targets an instance shared with other people.
+ *
+ * False on CI even at `localhost:8080`, and false for a rig on its own port.
+ * Every safety rule in a suite keys off this one answer: teardown deletes only
+ * recorded ids, the cross-run residue sweep reports instead of deleting, and
+ * specs that would change instance-wide settings refuse to run.
+ *
+ * @param target The base URL under test.
+ * @return True when the target is shared and this run said so.
+ */
+export function isSharedInstance(target: string): boolean {
+	return isCI() === false && isSharedOrigin(target)
+}
+
+/**
+ * The message an operator reads when they aimed at a shared instance without
+ * saying so.
+ *
+ * @param target The base URL they asked for.
+ * @param env    The environment to read.
+ * @return The full error text.
+ */
+function refusalMessage(
+	target: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	const origin = normaliseOrigin(target)
+	const setButWrong = SHARED_INSTANCE_FLAGS.map((name) => {
+		const value = (env[name] ?? '').trim()
+		if (value === '') return ''
+		return (
+			`${name} is set to "${value}", which normalises to `
+			+ `${normaliseOrigin(value)} and does not match ${origin}.\n`
+		)
+	}).join('')
+
+	return (
+		`[${APP_ID} e2e] ${target} is the SHARED development instance, and this run `
+		+ 'did not say it meant to go there.\n'
+		+ setButWrong
+		+ 'That instance bind-mounts host checkouts and holds data your colleagues '
+		+ 'are working on. This suite seeds and deletes objects.\n\n'
+		+ 'Point the suite at your own disposable rig:\n\n'
+		+ '    PLAYWRIGHT_BASE_URL=http://localhost:8095 npx playwright test\n\n'
+		+ 'Or aim at the shared instance on purpose, naming the origin you permit:\n\n'
+		+ `    ${SHARED_INSTANCE_FLAG}=${origin} \\\n`
+		+ `    PLAYWRIGHT_BASE_URL=${target} \\\n`
+		+ '    npx playwright test\n\n'
+		+ `Read the header of tests/e2e/shared-instance.ts first. The flag changes `
+		+ 'what teardown may delete and what the residue sweep may remove.'
+	)
+}
+
+/**
+ * Refuse the run when it aims at a shared instance without the opt-in.
+ *
+ * Call this from the module that resolves the base URL, on the resolved value,
+ * so there is one place a target can enter the suite.
+ *
+ * @param target The base URL under test.
+ * @param env    The environment to read.
+ * @return The target, unchanged, so the call can be inlined.
+ * @throws when the target is shared and no flag names it.
+ */
+export function assertInstancePermitted(
+	target: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	if (isCI()) return target
+	if (isSharedOrigin(target) === false) return target
+	if (permittingFlag(target, env) !== null) return target
+	throw new Error(refusalMessage(target, env))
+}
+
+/**
+ * Refuse one capability on a shared instance, even when the flag permitted the
+ * suite itself.
+ *
+ * For work that changes instance-wide state: enabling a workflow engine,
+ * flipping an app setting, purging a register. Call it from `test.beforeAll`
+ * so the refusal is reported as a failure with its reason. A skip reads as
+ * "nothing to see here", which is the opposite of the message.
+ *
+ * @param target The base URL under test.
+ * @param what   The spec or capability being refused.
+ * @param reason Why it must not run on a shared instance.
+ * @throws when this run targets a shared instance.
+ */
+export function refuseOnSharedInstance(
+	target: string,
+	what: string,
+	reason: string,
+): void {
+	if (isSharedInstance(target) === false) return
+	throw new Error(
+		`[${APP_ID} e2e] ${what} must not run on ${target}.\n`
+		+ `${reason}\n`
+		+ `${SHARED_INSTANCE_FLAG} permits the suite on a shared instance. It does `
+		+ 'not permit this.\n'
+		+ 'Start a disposable rig and point the suite at that instead:\n\n'
+		+ '    PLAYWRIGHT_BASE_URL=http://localhost:8095 npx playwright test\n',
+	)
+}
+
+/**
+ * The occ invocation for the instance under test, as a command prefix.
+ *
+ * The binding matters on a shared box: `php occ` run from this checkout talks
+ * to whatever server root sits two directories up, which on CI is the instance
+ * under test and on a dev box may be a different one entirely. Naming the
+ * container is how the two are tied together.
+ *
+ * Resolution order:
+ *  1. `OPENREGISTER_E2E_OCC`, a complete prefix, for any rig shape the guesses
+ *     below do not cover.
+ *  2. `OPENREGISTER_E2E_CONTAINER` or `NEXTCLOUD_CONTAINER`, a container name,
+ *     turned into `docker exec -u www-data <name> php occ`.
+ *  3. `php occ` from the server root, which is the CI case.
+ *
+ * @param env The environment to read.
+ * @return The argv prefix, already split, for `execFile` rather than a shell.
+ */
+export function occPrefix(env: NodeJS.ProcessEnv = process.env): string[] {
+	const explicit = (env.OPENREGISTER_E2E_OCC ?? '').trim()
+	if (explicit !== '') return explicit.split(/\s+/).filter((p) => p !== '')
+
+	const container = (
+		env.OPENREGISTER_E2E_CONTAINER ?? env.NEXTCLOUD_CONTAINER ?? ''
+	).trim()
+	if (container !== '') {
+		return ['docker', 'exec', '-u', 'www-data', container, 'php', 'occ']
+	}
+
+	return ['php', 'occ']
+}

--- a/tests/unit/shared-instance.test.ts
+++ b/tests/unit/shared-instance.test.ts
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Openregister Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * The guard that decides whether this suite may touch the instance it is aimed
+ * at, tested without an instance.
+ *
+ * GENERATED FROM hydra/templates/e2e/shared-instance.test.ts.tmpl. It lives
+ * under tests/unit/ rather than next to the guard because jest is this repo's
+ * unit runner and its testPathIgnorePatterns skips tests/e2e/ entirely, so a
+ * copy left beside the guard would never run. describe/expect/it come from
+ * jest's globals, which is the only other difference from the template.
+ *
+ * Worth testing rather than reading, because every case here is one somebody
+ * already got wrong: `http://127.0.0.1` parses with an EMPTY port, so a port
+ * comparison that trusts `URL.port` misses the shared instance written without
+ * one, and a flag holding `1` used to permit every shared instance the suite
+ * ever met.
+ */
+
+import {
+	APP_ID,
+	assertInstancePermitted,
+	isSharedOrigin,
+	normaliseOrigin,
+	occPrefix,
+	SHARED_INSTANCE_FLAG,
+	// ts-jest compiles this file against the repo tsconfig, which does not set
+	// allowImportingTsExtensions, so a ".ts" here fails the whole suite with
+	// TS5097 before a single case runs.
+	// eslint-disable-next-line import-extensions/extensions
+} from '../e2e/shared-instance'
+
+/** An environment with neither flag set. */
+const NONE = {} as NodeJS.ProcessEnv
+
+describe(`${APP_ID} shared-instance guard`, () => {
+	it('folds every loopback spelling onto localhost', () => {
+		expect(normaliseOrigin('http://127.0.0.1:8080')).toBe('http://localhost:8080')
+		expect(normaliseOrigin('http://[::1]:8080')).toBe('http://localhost:8080')
+		expect(normaliseOrigin('http://localhost:8080/')).toBe('http://localhost:8080')
+	})
+
+	it('makes the implicit port explicit', () => {
+		expect(normaliseOrigin('http://127.0.0.1')).toBe('http://localhost:80')
+		expect(normaliseOrigin('https://example.org')).toBe('https://example.org:443')
+	})
+
+	it('calls loopback 80 and 8080 shared, and nothing else', () => {
+		expect(isSharedOrigin('http://localhost:8080')).toBe(true)
+		expect(isSharedOrigin('http://127.0.0.1')).toBe(true)
+		expect(isSharedOrigin('http://localhost:8095')).toBe(false)
+		expect(isSharedOrigin('http://nextcloud.example.org:8080')).toBe(false)
+	})
+
+	it('refuses a shared instance that no flag names', () => {
+		expect(() => assertInstancePermitted('http://localhost:8080', NONE)).toThrow(
+			/SHARED development instance/,
+		)
+	})
+
+	it('refuses a flag holding a boolean rather than an origin', () => {
+		const env = { [SHARED_INSTANCE_FLAG]: '1' } as unknown as NodeJS.ProcessEnv
+		expect(() => assertInstancePermitted('http://localhost:8080', env)).toThrow()
+	})
+
+	it('refuses a flag that names a different origin', () => {
+		const env = {
+			[SHARED_INSTANCE_FLAG]: 'http://localhost:80',
+		} as unknown as NodeJS.ProcessEnv
+		expect(() => assertInstancePermitted('http://localhost:8080', env)).toThrow()
+	})
+
+	it('permits the origin the flag names, in any loopback spelling', () => {
+		const env = {
+			[SHARED_INSTANCE_FLAG]: 'http://127.0.0.1:8080',
+		} as unknown as NodeJS.ProcessEnv
+		expect(assertInstancePermitted('http://localhost:8080', env)).toBe(
+			'http://localhost:8080',
+		)
+	})
+
+	it('accepts the fleet-wide spelling too', () => {
+		const env = {
+			E2E_ALLOW_SHARED_INSTANCE: 'http://localhost:8080',
+		} as unknown as NodeJS.ProcessEnv
+		expect(assertInstancePermitted('http://localhost:8080', env)).toBe(
+			'http://localhost:8080',
+		)
+	})
+
+	it('lets a disposable rig through without a flag', () => {
+		expect(assertInstancePermitted('http://localhost:8095', NONE)).toBe(
+			'http://localhost:8095',
+		)
+	})
+
+	it('binds occ to a named container, and falls back to the server root', () => {
+		expect(occPrefix(NONE).join(' ')).toBe('php occ')
+		const env = { NEXTCLOUD_CONTAINER: 'nextcloud' } as NodeJS.ProcessEnv
+		expect(occPrefix(env).join(' ')).toBe(
+			'docker exec -u www-data nextcloud php occ',
+		)
+	})
+})

--- a/tests/unit/shared-instance.test.ts
+++ b/tests/unit/shared-instance.test.ts
@@ -6,10 +6,10 @@
  * at, tested without an instance.
  *
  * GENERATED FROM hydra/templates/e2e/shared-instance.test.ts.tmpl. It lives
- * under tests/unit/ rather than next to the guard because jest is this repo's
- * unit runner and its testPathIgnorePatterns skips tests/e2e/ entirely, so a
- * copy left beside the guard would never run. describe/expect/it come from
- * jest's globals, which is the only other difference from the template.
+ * under tests/unit/ because jest is this repo's unit runner and its
+ * testPathIgnorePatterns skips tests/e2e, so a copy beside the guard would
+ * never run. describe/expect/it/beforeEach/afterEach come from jest's
+ * globals, and the CI stub is written by hand because jest has no vi.stubEnv.
  *
  * Worth testing rather than reading, because every case here is one somebody
  * already got wrong: `http://127.0.0.1` parses with an EMPTY port, so a port
@@ -34,16 +34,47 @@ import {
 /** An environment with neither flag set. */
 const NONE = {} as NodeJS.ProcessEnv
 
+/*
+ * The guard exempts CI, and a unit runner runs ON CI. So without this, the
+ * three refusal cases below pass on a laptop and fail on every runner:
+ * measured before the stub, `CI=true npx jest` gave 3 failed, 7 passed.
+ * A test whose verdict depends on where it runs is worse than no test.
+ */
+
 describe(`${APP_ID} shared-instance guard`, () => {
+	// jest has no vi.stubEnv, so the two variables are saved and restored by
+	// hand. Same contract: the cases below never see a CI environment.
+	const saved: Record<string, string | undefined> = {}
+
+	beforeEach(() => {
+		for (const name of ['CI', 'GITHUB_ACTIONS']) {
+			saved[name] = process.env[name]
+			delete process.env[name]
+		}
+	})
+
+	afterEach(() => {
+		for (const name of ['CI', 'GITHUB_ACTIONS']) {
+			if (saved[name] === undefined) delete process.env[name]
+			else process.env[name] = saved[name]
+		}
+	})
+
 	it('folds every loopback spelling onto localhost', () => {
-		expect(normaliseOrigin('http://127.0.0.1:8080')).toBe('http://localhost:8080')
+		expect(normaliseOrigin('http://127.0.0.1:8080')).toBe(
+			'http://localhost:8080',
+		)
 		expect(normaliseOrigin('http://[::1]:8080')).toBe('http://localhost:8080')
-		expect(normaliseOrigin('http://localhost:8080/')).toBe('http://localhost:8080')
+		expect(normaliseOrigin('http://localhost:8080/')).toBe(
+			'http://localhost:8080',
+		)
 	})
 
 	it('makes the implicit port explicit', () => {
 		expect(normaliseOrigin('http://127.0.0.1')).toBe('http://localhost:80')
-		expect(normaliseOrigin('https://example.org')).toBe('https://example.org:443')
+		expect(normaliseOrigin('https://example.org')).toBe(
+			'https://example.org:443',
+		)
 	})
 
 	it('calls loopback 80 and 8080 shared, and nothing else', () => {


### PR DESCRIPTION
## What this does

The dev box runs one Nextcloud on `localhost:8080` that bind-mounts every
checkout under `apps-extra/`. A Playwright suite seeds objects and deletes them
again, so a run that lands there is not testing, it is editing a colleague's
environment. Aiming at it is allowed. Aiming at it by accident is not.

`tests/e2e/shared-instance.ts` is the guard (rendered from the hydra template,
hydra#665). It refuses a loopback target on port 80 or 8080 unless the run names
that exact origin in an opt-in variable:

```
OPENREGISTER_E2E_ALLOW_SHARED_INSTANCE=http://localhost:8080 \
PLAYWRIGHT_BASE_URL=http://localhost:8080 \
npx playwright test
```

The flag holds an origin, not `1`, so a value left in a shell profile permits
the one instance it names and nothing else. CI is exempt: there `localhost:8080`
is the runner's own throwaway Nextcloud.

## Where it is wired

One line, on the resolved value, in the module that already resolves the base
URL: `resolveBaseUrl()` in `tests/e2e/base-url.ts` now ends with
`assertInstancePermitted(...)`.

`playwright.flow.config.ts` was a second entrance. It computed its own
`process.env.NEXTCLOUD_URL || 'http://localhost:8080'` and never touched the
resolver, so it was the config that would actually have reached the shared
instance. It now imports `resolveBaseUrl()`. `NEXTCLOUD_URL` is still read, the
resolver reads it; only the hardcoded fallback is gone, and that fallback was
the shared instance.

No spec files changed.

`tests/newman/build-flow-engine-collection.mjs` and
`build-flow-subjects-collection.mjs` also carry the `http://localhost:8080`
literal. Those are Newman collection builders, not Playwright entrances, so
they are left alone here.

## Verified

Node 24.11.1 / npm 11.19.1, the CI pins.

- `npm ci`: exit 0.
- `npx eslint tests/e2e/shared-instance.ts tests/unit/shared-instance.test.ts tests/e2e/base-url.ts playwright.flow.config.ts`: exit 0.
- `npx jest tests/unit/shared-instance.test.ts`: 10 passed. Also 10 passed
  under `CI=true`, which matters because the guard exempts CI and the unit
  runner runs on CI: without that the three refusal cases passed here and
  failed on every runner (measured on this branch: 3 failed, 7 passed).
- `npx prettier --check` on all four touched files: all matched files use
  Prettier code style. That is a separate CI leg from eslint and the first push
  failed it.
- The test is provably collected, not dark: the whole jest suite reports 37
  suites / 324 tests without it and 38 suites / 334 tests with it.
- Playwright collects the same suite as before: `npx playwright test --list`
  gives `Total: 259 tests in 53 files` on development and on this branch.
- The guard actually refuses, and the flag actually permits:

```
refused-without-flag: true permitted-with-flag: http://localhost:8080
refusal-first-line: [openregister e2e] http://localhost:8080 is the SHARED development instance, and this run did not say it meant to go there.
```

- Both configs refuse at the shared origin, and a rig port still collects:

```
$ NEXTCLOUD_URL=http://localhost:8080 npx playwright test --config playwright.flow.config.ts --list
Error: [openregister e2e] http://localhost:8080 is the SHARED development instance ...
$ NEXTCLOUD_URL=http://localhost:8080 npx playwright test --list
Error: [openregister e2e] http://localhost:8080 is the SHARED development instance ...
$ NEXTCLOUD_URL=http://localhost:8095 npx playwright test --list
Total: 259 tests in 53 files
```

- `npm run lint` (whole tree): exit 0, 932 warnings, all inherited. None of them
  is on a line this PR touched.
- No PHP file changes in this diff, so `composer check:strict` has nothing to
  say about it.

## Where the unit test lives, and why not next to the guard

jest is this repo's unit runner and its `testPathIgnorePatterns` names
`<rootDir>/tests/e2e/`, so a test file placed beside the guard would have passed
when invoked by path and never run in CI. It lives in `tests/unit/` instead,
which `npm test` does collect. Two deliberate differences from the template:
`describe/expect/it` come from jest's globals rather than a `vitest` import, and
the import of the guard carries no `.ts` extension because ts-jest compiles
against the repo tsconfig, which does not set `allowImportingTsExtensions`. That
one line carries an `eslint-disable-next-line` with the reason written above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
