### PR TITLE
feat(lifecycle): provider mode can take the move it offers

### DIFF
--- a/lib/Controller/TransitionController.php
+++ b/lib/Controller/TransitionController.php
@@ -29,6 +29,7 @@ namespace OCA\OpenRegister\Controller;
 use OCA\OpenRegister\Exception\HookStoppedException;
 use OCA\OpenRegister\Exception\InvalidTransitionInputException;
 use OCA\OpenRegister\Exception\LifecycleProviderException;
+use OCA\OpenRegister\Exception\LifecycleSubjectNotFoundException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCP\AppFramework\Controller;
@@ -122,9 +123,33 @@ class TransitionController extends Controller {
 				['error' => $e->getMessage()],
 				Http::STATUS_UNPROCESSABLE_ENTITY
 			);
+		} catch (LifecycleSubjectNotFoundException $e) {
+			// The object itself is gone. Caught BEFORE the RuntimeException
+			// branch it extends: "someone deleted this case" and "this case
+			// cannot take that move" are different things to tell a handler,
+			// and they answered the same 422 until this type existed. 404 is
+			// what the read half of the same pair already answers.
+			return new JSONResponse(
+				['error' => $e->getMessage()],
+				Http::STATUS_NOT_FOUND
+			);
+		} catch (LifecycleProviderException $e) {
+			// A provider-mode lifecycle could not be RUN: the declared tag
+			// resolves to nothing, the provider failed in a way it never
+			// planned for, or the object could not be read back afterwards.
+			// Caught BEFORE the RuntimeException branch it extends, because a
+			// broken provider is not a refused move. 422 would tell a handler
+			// the move was considered and declined; 502 says the truthful
+			// thing, that OpenRegister asked an upstream and did not get an
+			// answer. The provider's own refusals stay 422 below — they are
+			// ordinary RuntimeExceptions by contract.
+			return new JSONResponse(
+				['error' => $e->getMessage()],
+				Http::STATUS_BAD_GATEWAY
+			);
 		} catch (RuntimeException $e) {
-			// Engine throws on missing object/schema/transition or
-			// disallowed-from-current-state.
+			// Engine throws on missing schema/transition,
+			// disallowed-from-current-state, or a provider refusing the move.
 			return new JSONResponse(
 				['error' => $e->getMessage()],
 				Http::STATUS_UNPROCESSABLE_ENTITY

--- a/lib/Exception/LifecycleSubjectNotFoundException.php
+++ b/lib/Exception/LifecycleSubjectNotFoundException.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * OpenRegister LifecycleSubjectNotFoundException
+ *
+ * Raised when the object a lifecycle call names does not exist.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Exception
+ * @package  OCA\OpenRegister\Exception
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Exception;
+
+use RuntimeException;
+
+/**
+ * The object a transition was asked for does not exist.
+ *
+ * Extends `RuntimeException` so REQ-007's "throw `RuntimeException` if not
+ * found" still holds literally and every existing catch site behaves as it
+ * did. It is a distinct type for one reason: the transition endpoint has
+ * three failures a client must tell apart, and until this class existed two
+ * of them shared a status code.
+ *
+ * - A move the object cannot take is a REFUSAL — HTTP 422, `RuntimeException`.
+ * - A provider that could not run at all is a BREAKAGE — HTTP 502,
+ *   {@see LifecycleProviderException}.
+ * - An object that is not there is MISSING — HTTP 404, this class.
+ *
+ * The third used to answer 422 alongside the first, so "someone deleted this
+ * case" and "this case cannot move yet" reached a handler as the same colour
+ * of error. `TransitionController::availableActions()` already answered 404
+ * for the read of a missing object; this is the write half of the same
+ * sentence.
+ */
+class LifecycleSubjectNotFoundException extends RuntimeException {
+}//end class

--- a/lib/Lifecycle/LifecycleActionProviderInterface.php
+++ b/lib/Lifecycle/LifecycleActionProviderInterface.php
@@ -38,11 +38,17 @@ namespace OCA\OpenRegister\Lifecycle;
  * already delegates guards (`LifecycleGuardInterface`) and actions
  * (`LifecycleActionInterface`).
  *
- * Providers are read-only — they MUST NOT mutate the object, and MUST NOT
- * write anything derived from it. They are called on a GET request that the
- * caller may repeat at will. Side effects (notifications, cascades,
- * derived-field maintenance) belong on `ObjectTransitionedEvent` listeners,
- * not in the provider.
+ * A provider answers both halves of the mode. `availableActions()` is the
+ * read: it MUST NOT mutate the object, because it is called on a GET the
+ * caller may repeat at will. `execute()` is the write: it performs the move
+ * it offered, and it is the only place the move happens.
+ *
+ * BOTH ARE MANDATORY ON PURPOSE. An interface where the write half were
+ * optional would let an app declare provider mode, publish a timeline of
+ * moves, and have every click refused — which is the defect this pair exists
+ * to close (openregister#3679). A provider with nothing to offer says so by
+ * answering an empty list; a provider that refuses a particular move says so
+ * by throwing from `execute()`. Neither needs a half-implemented contract.
  *
  * A provider that cannot answer MUST throw. Returning an empty list says
  * "this object genuinely offers no moves", which a client renders as a dead
@@ -68,4 +74,72 @@ interface LifecycleActionProviderInterface {
 	 * @spec openspec/specs/object-lifecycle/spec.md
 	 */
 	public function availableActions(array $object, string $userId): array;
+
+	/**
+	 * Perform one of the moves this provider offered.
+	 *
+	 * THE PROVIDER DOES THE WRITE, OpenRegister does not. That is the whole
+	 * shape of this method and it is deliberate. An app that owns a state
+	 * machine owns more than the field the status lands in: dossiq's
+	 * `StatusTransitionService::execute()` re-evaluates the transition's
+	 * guards, takes an optimistic version lock, refuses a closing move that
+	 * carries no result, writes the status record, and dispatches the
+	 * transition's side effects. A contract that answered "here is the new
+	 * value, you save it" would strand every one of those, and OpenRegister
+	 * would have to learn the app's model to run them — which is exactly what
+	 * provider mode exists to avoid.
+	 *
+	 * It also means there is ONE authority. The provider re-validates the move
+	 * with the same reader `availableActions()` used, so a move that became
+	 * unreachable between the read and the click is refused by the same code
+	 * that decided it was reachable, not by a second derivation that can
+	 * disagree with the first.
+	 *
+	 * THE RETURN VALUE IS A REPORT, NOT THE OBJECT. OpenRegister re-reads the
+	 * object through its own read path after this returns, so what it answers
+	 * the client with is the stored truth rather than the provider's echo of
+	 * it. Exactly one key is read off this array: `to`, the state the object
+	 * moved into, used for the `ObjectTransitionedEvent`. When it is absent
+	 * OpenRegister reads the annotation's lifecycle field off the re-read
+	 * object instead, so a provider whose own result shape says nothing about
+	 * the target state — dossiq's returns `status`/`statusRecord`/
+	 * `dispatchedActions`/`version` — can return it verbatim. Every other key
+	 * is ignored and is free for the app's own callers.
+	 *
+	 * REFUSING A MOVE AND BEING BROKEN ARE DIFFERENT THROWS, and an app MUST
+	 * keep them apart because the caller's status code depends on it:
+	 *
+	 * - A REFUSAL — a guard said no, the object already moved, a required
+	 *   input is missing, the object is not one this provider knows — throws
+	 *   any ordinary `RuntimeException`. Its message reaches the user as HTTP
+	 *   422, so write it as a sentence a handler can act on.
+	 * - BEING BROKEN — the workflow template will not parse, storage is down,
+	 *   a dependency is missing — throws
+	 *   {@see \OCA\OpenRegister\Exception\LifecycleProviderException}, which
+	 *   reaches the caller as HTTP 502. Anything else that escapes (a
+	 *   `TypeError`, an `Error`) is wrapped into one, because an unplanned
+	 *   failure is never a refusal.
+	 *
+	 * A refusal MUST leave the object untouched: it is reported to a user as
+	 * "that move did not happen", and a half-applied refusal makes that a lie.
+	 *
+	 * A move MUST NOT delete the object. OpenRegister answers the write
+	 * endpoint with the transitioned object, so an object that is gone
+	 * afterwards leaves it nothing truthful to answer with, and it reports
+	 * that as a provider failure.
+	 *
+	 * @param array<string, mixed> $object The loaded object payload as it stood before the move.
+	 * @param string $userId The uid of the caller, empty when there is no session user.
+	 * @param string $action The action name, one this provider published from `availableActions()`.
+	 * @param array<string, mixed> $data The input values the caller supplied, keyed by field.
+	 *
+	 * @return array<string, mixed> The provider's report of the move. `to` is read when present;
+	 *                              every other key is the app's own.
+	 *
+	 * @throws \RuntimeException When the move is refused.
+	 * @throws \OCA\OpenRegister\Exception\LifecycleProviderException When the provider is broken.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	public function execute(array $object, string $userId, string $action, array $data): array;
 }//end interface

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -36,6 +36,7 @@ use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\OpenRegister\Exception\HookStoppedException;
 use OCA\OpenRegister\Exception\InvalidTransitionInputException;
 use OCA\OpenRegister\Exception\LifecycleProviderException;
+use OCA\OpenRegister\Exception\LifecycleSubjectNotFoundException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Object\PermissionHandler;
 use OCA\OpenRegister\Service\ObjectService;
@@ -316,7 +317,11 @@ class TransitionEngine {
 	private function resolveTransitionSubject(string $objectId): array {
 		$object = $this->objectService->find(id: $objectId);
 		if ($object === null) {
-			throw new RuntimeException(sprintf('Object "%s" not found.', $objectId));
+			// A distinct type, still a RuntimeException: the write endpoint has
+			// to tell "this object is gone" (404) apart from "this move was
+			// refused" (422) and "the provider broke" (502), and those first two
+			// shared a status code until this type existed.
+			throw new LifecycleSubjectNotFoundException(sprintf('Object "%s" not found.', $objectId));
 		}
 
 		$schema = $this->loadSchema(object: $object);
@@ -376,10 +381,24 @@ class TransitionEngine {
 		$field = (string)($annotation['field'] ?? ($annotation['property'] ?? ''));
 		$transitions = (array)($annotation['transitions'] ?? []);
 
-		// Static transitions take precedence. Graph mode applies only when no
-		// non-empty static `transitions` map is declared (design: mode
-		// selection & precedence — zero regression for static schemas).
+		// Static transitions take precedence, then the two delegating modes in
+		// the SAME order the read path resolves them: `provider` before
+		// `graph` (design: mode selection & precedence — zero regression for
+		// static schemas). The two paths must agree here or a schema can be
+		// offered moves by one mode and judged by another, which is the
+		// disagreement a user meets as a stage that highlights and then fails.
 		if ($transitions === []) {
+			$provider = trim((string)($annotation['provider'] ?? ''));
+			if ($provider !== '') {
+				return $this->applyProviderTransition(
+					object: $object,
+					tag: $provider,
+					field: $field,
+					action: $action,
+					data: $data
+				);
+			}
+
 			$graph = (array)($annotation['graph'] ?? []);
 			if ($graph !== []) {
 				return $this->applyGraphTransition(
@@ -464,6 +483,177 @@ class TransitionEngine {
 
 		return $saved;
 	}//end applyTransition()
+
+	/**
+	 * Hand a provider-mode transition to the app that owns the state machine.
+	 *
+	 * THE PROVIDER PERFORMS THE WRITE. OpenRegister resolves the tag, hands
+	 * over the object, the caller and the payload, and then re-reads. It does
+	 * not mutate the lifecycle field itself and it does not call
+	 * `saveObject()`. An app whose state machine is data owns more than the
+	 * field the status lands in — dossiq's `StatusTransitionService::execute()`
+	 * re-evaluates the transition's guards, takes an optimistic version lock,
+	 * refuses a closing move that carries no result, writes the status record
+	 * and dispatches the transition's side effects. A branch that took a new
+	 * value back and saved it would strand every one of those.
+	 *
+	 * THE ACTION IS NOT RE-DERIVED HERE, deliberately. OpenRegister does not
+	 * call `availableActions()` to check the posted action is one that was
+	 * published: the provider re-validates with the same reader it answered
+	 * the read with, so there is ONE authority. A check here would be a second
+	 * derivation, and a second derivation is what eventually disagrees with
+	 * the first. For the same reason `$data` is passed through untouched
+	 * rather than allowlisted: the `inputs` a client was shown came from the
+	 * provider, not from the schema, so the provider is the only thing that
+	 * can say whether they were satisfied.
+	 *
+	 * NO WRITE-BOUNDARY DECLARATION, and not by omission. The static path
+	 * calls {@see LifecycleWriteBoundary::declaringAction()} so the lifecycle
+	 * listeners judge the named transition rather than the first one sharing
+	 * its from/to pair. In provider mode there is no such name to look up: the
+	 * annotation carries no `transitions` map, so the listeners have nothing
+	 * to match and the declaration would tell them a name they cannot resolve.
+	 * Worse, it would claim OpenRegister is applying a named transition to
+	 * this uuid through its own save pipeline while in fact the app is writing
+	 * — across several objects — and it would hold that claim open for the
+	 * whole app call rather than around one save, which is precisely the
+	 * widened frame `declaringAction()`'s `finally` exists to prevent. The
+	 * enforcement the declaration supports has not been lost, it has moved:
+	 * the provider re-validates the move itself. That is the difference from
+	 * graph mode, which skips the declaration AND has nothing re-checking it,
+	 * which is why graph mode is documented as unenforced and this is not.
+	 *
+	 * The automatic-transition boundary still frames the write: `transition()`
+	 * wraps every mode in {@see LifecycleWriteBoundary::around()}, so a
+	 * rule-driven move that follows from this one is still drained and still
+	 * wins the entity that is answered.
+	 *
+	 * @param ObjectEntity $object The transitioning object, as it stood before the move.
+	 * @param string $tag The `provider` DI tag off the annotation.
+	 * @param string $field The lifecycle field name on the object.
+	 * @param string $action The action name the caller posted.
+	 * @param array<string, mixed> $data The caller-supplied input values.
+	 *
+	 * @return ObjectEntity The object re-read after the provider's write.
+	 *
+	 * @throws RuntimeException When the provider refuses the move.
+	 * @throws LifecycleProviderException When the tag resolves to nothing, resolves to the wrong
+	 *                          type, the provider fails unexpectedly, or the object cannot be
+	 *                          re-read afterwards.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function applyProviderTransition(
+		ObjectEntity $object,
+		string $tag,
+		string $field,
+		string $action,
+		array $data = [],
+	): ObjectEntity {
+		$provider = $this->providerRegistry->resolve(tag: $tag);
+
+		$actingUser = $this->userSession->getUser();
+		$objectId = (string)$object->getUuid();
+		$before = ($object->getObject() ?? []);
+		$from = (string)($before[$field] ?? '');
+
+		try {
+			$report = $provider->execute(
+				object: $before,
+				userId: (string)($actingUser?->getUID() ?? ''),
+				action: $action,
+				data: $data
+			);
+		} catch (RuntimeException $e) {
+			// THE APP SPEAKING, in the vocabulary the interface documents, so
+			// nothing is wrapped and nothing is reclassified. An ordinary
+			// RuntimeException is a refusal and reaches the caller as 422 with
+			// the provider's own sentence; a LifecycleProviderException is a
+			// declared breakage and reaches it as 502. Both are already the
+			// type the controller maps, and rewriting either would turn "the
+			// deadline has passed" into "the upstream is down" or the reverse.
+			throw $e;
+		} catch (Throwable $e) {
+			// ANYTHING ELSE IS NOT A REFUSAL. A TypeError or an Error means
+			// the provider failed in a way it never planned for, and reporting
+			// that as 422 would tell a handler the move was considered and
+			// declined when it was never considered at all.
+			$this->logger->error(
+				sprintf(
+					'Lifecycle provider "%s" failed to apply action "%s" to object "%s": %s',
+					$tag,
+					$action,
+					$objectId,
+					$e->getMessage()
+				),
+				['exception' => $e]
+			);
+			throw new LifecycleProviderException(
+				message: sprintf('Lifecycle provider "%s" could not apply action "%s".', $tag, $action),
+				code: 0,
+				previous: $e
+			);
+		}//end try
+
+		// Re-read rather than trust the report: what the client is answered
+		// with is the stored object, including whatever the provider's own
+		// side effects stamped onto it.
+		$saved = $this->objectService->find(id: $objectId);
+		if ($saved === null) {
+			$this->logger->error(
+				sprintf(
+					'Lifecycle provider "%s" applied action "%s" but object "%s" could not be re-read.',
+					$tag,
+					$action,
+					$objectId
+				)
+			);
+			throw new LifecycleProviderException(
+				message: sprintf(
+					'Lifecycle provider "%s" applied action "%s" but the object could not be read back.',
+					$tag,
+					$action
+				)
+			);
+		}
+
+		$this->dispatchTransitioned(
+			object: $saved,
+			action: $action,
+			from: $from,
+			to: $this->providerTargetState(report: $report, saved: $saved, field: $field),
+			userId: $actingUser?->getUID()
+		);
+
+		return $saved;
+	}//end applyProviderTransition()
+
+	/**
+	 * The state a provider moved the object into, for the transitioned event.
+	 *
+	 * The provider's report MAY name it as `to`, which is the only key
+	 * OpenRegister reads off that array. When it does not — dossiq's own
+	 * result shape is `status`/`statusRecord`/`dispatchedActions`/`version`,
+	 * and returning it verbatim is the point of ignoring the rest — the value
+	 * is read off the re-read object's lifecycle field, which is the stored
+	 * truth and cannot disagree with what was persisted.
+	 *
+	 * @param array<string, mixed> $report What the provider answered.
+	 * @param ObjectEntity $saved The object as re-read after the write.
+	 * @param string $field The lifecycle field name on the object.
+	 *
+	 * @return string The target state, empty when neither source names one.
+	 *
+	 * @spec openspec/specs/object-lifecycle/spec.md
+	 */
+	private function providerTargetState(array $report, ObjectEntity $saved, string $field): string {
+		$reported = trim((string)($report['to'] ?? ''));
+		if ($reported !== '') {
+			return $reported;
+		}
+
+		return (string)(($saved->getObject() ?? [])[$field] ?? '');
+	}//end providerTargetState()
 
 	/**
 	 * List actions whose `from` includes the object's current lifecycle value.

--- a/lib/Service/Lifecycle/TransitionEngine.php
+++ b/lib/Service/Lifecycle/TransitionEngine.php
@@ -321,7 +321,9 @@ class TransitionEngine {
 			// to tell "this object is gone" (404) apart from "this move was
 			// refused" (422) and "the provider broke" (502), and those first two
 			// shared a status code until this type existed.
-			throw new LifecycleSubjectNotFoundException(sprintf('Object "%s" not found.', $objectId));
+			throw new LifecycleSubjectNotFoundException(
+				message: sprintf('Object "%s" not found.', $objectId)
+			);
 		}
 
 		$schema = $this->loadSchema(object: $object);

--- a/openspec/specs/object-lifecycle/spec.md
+++ b/openspec/specs/object-lifecycle/spec.md
@@ -951,9 +951,10 @@ status list, or a policy table an administrator edits. When
 `x-openregister-lifecycle` declares a non-empty `provider` string and no
 non-empty static `transitions` map, `TransitionEngine::availableActions()` SHALL
 resolve that value through `LifecycleActionProviderRegistry` and SHALL publish
-what the resolved `LifecycleActionProviderInterface` answers. A provider is
-read-only: it MUST NOT mutate the object, because it is called on a GET the
-caller may repeat at will.
+what the resolved `LifecycleActionProviderInterface` answers.
+`availableActions()` on the provider is a read: it MUST NOT mutate the object,
+because it is called on a GET the caller may repeat at will. The move it offers
+is taken through the same interface's `execute()`, specified below.
 
 Mode precedence SHALL be static, then provider, then graph. A schema declaring a
 non-empty `transitions` map SHALL keep it whatever else it declares, so an
@@ -981,6 +982,81 @@ path will accept.
 - **WHEN** `availableActions()` is called
 - **THEN** that entry MUST be dropped and the remaining entries MUST be published as `{field, required}` pairs
 
+### Requirement: Lifecycle provider mode applies the move through the same app service
+
+A mode that can offer a move and not take it is worse than one that offers
+nothing, so the write path SHALL resolve `provider` exactly as the read path
+does. `TransitionEngine::transition()` SHALL select modes in the SAME order
+`availableActions()` uses — static `transitions`, then `provider`, then `graph`
+— and when a non-empty `provider` string is declared beside no non-empty static
+map, it SHALL resolve that tag through `LifecycleActionProviderRegistry` and
+call `LifecycleActionProviderInterface::execute($object, $userId, $action,
+$data)`.
+
+`execute()` is declared on the same interface as `availableActions()` and is
+MANDATORY, not an optional second interface: an app that may implement only the
+read half can publish a timeline whose every click is refused, which is the
+defect this requirement closes. A provider with nothing to offer says so by
+answering an empty list; a provider that refuses one move says so by throwing.
+
+THE PROVIDER PERFORMS THE WRITE. OpenRegister SHALL NOT mutate the lifecycle
+field and SHALL NOT call `ObjectService::saveObject()` on this path. An app
+whose state machine is data owns more than the field the status lands in —
+guard re-evaluation, an optimistic version lock, a required closing result, a
+status record, side-effect dispatch — and a branch that took a new value back
+and saved it would strand all of them and race the app's own write.
+
+OpenRegister SHALL NOT re-derive the posted action before handing it over, and
+SHALL pass `$data` through without allowlisting it. The provider re-validates
+with the same reader it answered the read with, so there is one authority; a
+check in the engine would be a second derivation that can disagree with the
+first, and the `inputs` a client was shown came from the provider rather than
+from the schema.
+
+After `execute()` returns, the engine SHALL re-read the object through
+`ObjectService::find()` and answer the endpoint with what is stored, not with
+the provider's echo of it. The provider's return value is a REPORT: exactly one
+key, `to`, is read off it, and when it is absent the target state SHALL be read
+off the re-read object's lifecycle field. Every other key is the app's own, so
+a provider may return its existing result shape verbatim. The engine SHALL then
+dispatch `ObjectTransitionedEvent` with the action, the pre-move value of the
+lifecycle field as `from`, and that target state as `to`.
+
+THE WRITE BOUNDARY IS DELIBERATELY NOT DECLARED on this path.
+`LifecycleWriteBoundary::declaringAction()` exists so the lifecycle listeners
+judge the named transition rather than the first one sharing its from/to pair.
+In provider mode the annotation carries no `transitions` map, so there is no
+name for them to look up; a declaration would tell them a name they cannot
+resolve, would claim OpenRegister is applying it through its own save pipeline
+while the app is writing across several objects, and would hold that claim open
+for the whole app call rather than around one save. The enforcement the
+declaration supports has not been lost, it has moved into the provider, which
+re-validates the move itself — which is the difference from graph mode, where
+the declaration is skipped AND nothing re-checks the move, and which is why
+graph mode is documented as unenforced and this is not.
+`LifecycleWriteBoundary::around()` still frames the write, because
+`transition()` wraps every mode in it, so a rule-driven move that follows from
+this one is still drained and still wins the entity that is answered.
+
+#### Scenario: A provider-mode schema takes the move it offered
+- **GIVEN** a schema whose `x-openregister-lifecycle` declares a `provider` tag and no static `transitions`
+- **AND** a registered provider that published an action for the object's current state
+- **WHEN** a client posts that action to the transition endpoint
+- **THEN** the provider's `execute()` MUST be called with the object payload, the caller's uid, the action and the posted data
+- **AND** OpenRegister MUST NOT save the object itself
+- **AND** the response MUST be the object as re-read after the provider's write
+
+#### Scenario: Static transitions take precedence over a provider on the write path
+- **GIVEN** a schema declaring both a non-empty `transitions` map and a `provider` tag
+- **WHEN** a declared static action is posted to the transition endpoint
+- **THEN** the static transition MUST be applied through `ObjectService::saveObject()`
+- **AND** the provider MUST NOT be resolved
+
+#### Scenario: The transitioned event names the state the object actually reached
+- **GIVEN** a provider whose report does not name a target state
+- **WHEN** its move is applied
+- **THEN** the dispatched `ObjectTransitionedEvent` MUST carry the lifecycle field of the re-read object as `to`
+
 ### Requirement: A provider that cannot answer MUST fail closed rather than return an empty list
 
 An empty action list is a successful answer meaning the object offers no moves
@@ -996,6 +1072,50 @@ Because a broken provider declaration fails at read time rather than at save
 time, `lifecycle-provider-invalid` and `lifecycle-provider-mode-conflict` SHALL
 refuse the schema save, unlike the advisory lifecycle findings that are stored as
 written.
+
+ON THE WRITE PATH, THREE FAILURES SHALL STAY DISTINGUISHABLE, because a handler
+acts differently on each: a refused move is retried differently, a broken
+provider is reported to someone, and a missing object is not retried at all.
+
+- A REFUSAL — a guard said no, the object already moved, a required input is
+  absent — SHALL be an ordinary `RuntimeException` from the provider, SHALL NOT
+  be wrapped or reclassified by the engine, and SHALL answer HTTP 422 carrying
+  the provider's own message. A refusal MUST leave the object untouched.
+- A BREAKAGE SHALL answer HTTP 502. The provider declares one by throwing
+  `LifecycleProviderException`; the engine raises one itself when the tag
+  resolves to nothing or to the wrong type, when the provider throws anything
+  that is not a `RuntimeException` (a `TypeError`, an `Error` — an unplanned
+  failure is never a considered refusal), and when the object cannot be re-read
+  after the write. A provider MUST NOT delete the object as part of a move,
+  because the endpoint has nothing truthful left to answer with.
+- A MISSING OBJECT SHALL answer HTTP 404, through
+  `LifecycleSubjectNotFoundException`, which extends `RuntimeException` so
+  REQ-007's "throw `RuntimeException` if not found" still holds and every
+  existing catch site is unchanged. This aligns the write path with the read
+  path, which already answered 404 for the same condition while the write path
+  reported it as a refusal.
+
+`TransitionController::transition()` SHALL catch these in that order —
+`LifecycleSubjectNotFoundException`, then `LifecycleProviderException`, then
+`RuntimeException` — because each extends the next and a reorder silently
+collapses one status into another.
+
+#### Scenario: A refused move answers 422 with the provider's sentence
+- **GIVEN** a registered provider whose `execute()` throws a `RuntimeException` explaining why the move is refused
+- **WHEN** a client posts that action to the transition endpoint
+- **THEN** the response status MUST be 422 and the body MUST carry the provider's message
+- **AND** no `ObjectTransitionedEvent` MUST be dispatched
+
+#### Scenario: A broken provider answers 502 on the write path
+- **GIVEN** a registered provider whose `execute()` throws a `TypeError`
+- **WHEN** a client posts an action to the transition endpoint
+- **THEN** the failure MUST be logged and raised as `LifecycleProviderException`
+- **AND** the response status MUST be 502, never 422
+
+#### Scenario: A missing object answers 404 on the write path
+- **GIVEN** an object id that resolves to nothing
+- **WHEN** a client posts an action to the transition endpoint
+- **THEN** the response status MUST be 404, distinct from the 422 a refused move answers
 
 #### Scenario: Unresolvable provider answers 502
 - **GIVEN** a schema declaring a `provider` tag that no app has registered

--- a/tests/Unit/Controller/TransitionControllerTest.php
+++ b/tests/Unit/Controller/TransitionControllerTest.php
@@ -27,6 +27,7 @@ use OCA\OpenRegister\Controller\TransitionController;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Exception\InvalidTransitionInputException;
 use OCA\OpenRegister\Exception\LifecycleProviderException;
+use OCA\OpenRegister\Exception\LifecycleSubjectNotFoundException;
 use OCA\OpenRegister\Exception\NotAuthorizedException;
 use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
 use OCP\AppFramework\Http;
@@ -140,6 +141,69 @@ class TransitionControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
 	}//end testTransitionReturns422OnRuntimeError()
+
+	/**
+	 * A provider that BROKE is not a move that was refused → 502, not 422.
+	 *
+	 * `LifecycleProviderException` extends `RuntimeException`, so this passes
+	 * only while it is caught ahead of the 422 branch. Reordering the
+	 * try/catch silently turns "the workflow template will not parse" into
+	 * "your move was declined", which a handler acts on by trying something
+	 * else instead of calling someone.
+	 *
+	 * @return void
+	 */
+	public function testTransitionReturns502WhenTheProviderCannotApplyTheMove(): void {
+		$this->stubParams(['action' => 'lc-start']);
+		$this->engine->method('transition')->willThrowException(
+			new LifecycleProviderException('Lifecycle provider "x" could not apply action "lc-start".')
+		);
+
+		$response = $this->controller->transition('obj-1');
+
+		$this->assertSame(Http::STATUS_BAD_GATEWAY, $response->getStatus());
+	}//end testTransitionReturns502WhenTheProviderCannotApplyTheMove()
+
+	/**
+	 * A provider that REFUSED the move keeps the 422, with its own sentence.
+	 *
+	 * The pair with the 502 above: together they are what makes either status
+	 * readable. A refusal is the app answering in its own vocabulary, so the
+	 * message is the thing the user is shown.
+	 *
+	 * @return void
+	 */
+	public function testTransitionReturns422WhenTheProviderRefusesTheMove(): void {
+		$this->stubParams(['action' => 'lc-start']);
+		$this->engine->method('transition')->willThrowException(
+			new RuntimeException('De bezwaartermijn is verstreken.')
+		);
+
+		$response = $this->controller->transition('obj-1');
+
+		$this->assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		$this->assertSame(
+			['error' => 'De bezwaartermijn is verstreken.'],
+			$response->getData()
+		);
+	}//end testTransitionReturns422WhenTheProviderRefusesTheMove()
+
+	/**
+	 * An object that is GONE is neither → 404, the status the read half of
+	 * this pair already answers for the same condition.
+	 *
+	 * @return void
+	 */
+	public function testTransitionReturns404OnMissingObject(): void {
+		$this->stubParams(['action' => 'lc-start']);
+		$this->engine->method('transition')->willThrowException(
+			new LifecycleSubjectNotFoundException('Object "obj-1" not found.')
+		);
+
+		$response = $this->controller->transition('obj-1');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}//end testTransitionReturns404OnMissingObject()
 
 	/**
 	 * The optional `data` body param is forwarded to the engine untouched.

--- a/tests/Unit/Service/Lifecycle/TransitionEngineProviderWriteTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineProviderWriteTest.php
@@ -440,21 +440,18 @@ class TransitionEngineProviderWriteTest extends TestCase {
 	}//end testStaticTransitionsTakePrecedenceOverTheProvider()
 
 	/**
-	 * A SCHEMA WITH NO PROVIDER IS UNAFFECTED: the branch is entered only on a
-	 * non-empty `provider` string, so a static schema still refuses an
-	 * undeclared action with the message it always did, and no provider is
-	 * resolved on the way there.
+	 * A SCHEMA WITH NO PROVIDER IS UNAFFECTED, and this is the case that
+	 * actually reaches the new branch's guard: an annotation declaring no mode
+	 * at all falls straight past it, refuses the undeclared action with the
+	 * message it always did, and resolves no provider on the way there. A
+	 * schema declaring a static map never gets this far, so it cannot pin the
+	 * guard — {@see testStaticTransitionsTakePrecedenceOverTheProvider} pins
+	 * that half.
 	 */
 	public function testASchemaWithoutAProviderIsUnaffected(): void {
 		$this->registry->expects($this->never())->method('resolve');
 
-		$this->wire(
-			$this->caseObject(),
-			[
-				'field' => 'status',
-				'transitions' => ['goedkeuren' => ['from' => ['ontvangen'], 'to' => 'afgehandeld']],
-			]
-		);
+		$this->wire($this->caseObject(), ['field' => 'status']);
 
 		$this->expectException(RuntimeException::class);
 		$this->expectExceptionMessage('is not declared on this schema');

--- a/tests/Unit/Service/Lifecycle/TransitionEngineProviderWriteTest.php
+++ b/tests/Unit/Service/Lifecycle/TransitionEngineProviderWriteTest.php
@@ -1,0 +1,483 @@
+<?php
+
+/**
+ * OpenRegister TransitionEngine provider-mode WRITE tests
+ *
+ * The other half of provider mode: the app that answered "these are the
+ * moves" is also the one that takes them. Asserts that the provider is asked
+ * rather than the lifecycle field mutated, that OpenRegister saves nothing
+ * itself, that the object is re-read afterwards, that a refusal and a
+ * breakage stay different throws, that static transitions still win, and
+ * that a schema declaring no provider never reaches this path at all.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Test
+ * @package  OCA\OpenRegister\Tests\Unit\Service\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://www.OpenRegister.app
+ */
+
+declare(strict_types=1);
+
+namespace Unit\Service\Lifecycle;
+
+use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\Schema;
+use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\OpenRegister\Exception\LifecycleProviderException;
+use OCA\OpenRegister\Lifecycle\LifecycleActionProviderInterface;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleActionContext;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleActionProviderRegistry;
+use OCA\OpenRegister\Service\Lifecycle\LifecycleWriteBoundary;
+use OCA\OpenRegister\Service\Lifecycle\TransitionEngine;
+use OCA\OpenRegister\Service\Object\PermissionHandler;
+use OCA\OpenRegister\Service\ObjectService;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * @coversDefaultClass \OCA\OpenRegister\Service\Lifecycle\TransitionEngine
+ */
+class TransitionEngineProviderWriteTest extends TestCase {
+	private const CASE = '00000000-0000-0000-0000-0000000000aa';
+
+	private const TAG = 'OCA\\Dossiq\\Lifecycle\\CaseActionProvider';
+
+	private const ACTION = 'lc-start';
+
+	private ObjectService&MockObject $objectService;
+
+	private SchemaMapper&MockObject $schemaMapper;
+
+	private LifecycleActionProviderRegistry&MockObject $registry;
+
+	private IEventDispatcher&MockObject $dispatcher;
+
+	private LoggerInterface&MockObject $logger;
+
+	private LifecycleActionContext $actions;
+
+	private TransitionEngine $engine;
+
+	protected function setUp(): void {
+		$this->objectService = $this->createMock(ObjectService::class);
+		$this->schemaMapper = $this->createMock(SchemaMapper::class);
+		$this->registry = $this->createMock(LifecycleActionProviderRegistry::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->actions = new LifecycleActionContext();
+
+		$this->engine = new TransitionEngine(
+			$this->objectService,
+			$this->schemaMapper,
+			$this->dispatcher,
+			$this->createMock(IUserSession::class),
+			$this->permission(),
+			$this->createMock(RegisterMapper::class),
+			$this->appConfig(),
+			$this->logger,
+			new LifecycleWriteBoundary($this->actions),
+			$this->registry
+		);
+	}//end setUp()
+
+	/**
+	 * A permission handler that says yes, so the RBAC gate is out of the way.
+	 */
+	private function permission(): PermissionHandler&MockObject {
+		$permission = $this->createMock(PermissionHandler::class);
+		$permission->method('hasPermission')->willReturn(true);
+		return $permission;
+	}//end permission()
+
+	/**
+	 * App config that answers every read with the caller's default.
+	 */
+	private function appConfig(): IAppConfig&MockObject {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')
+			->willReturnCallback(
+				static function (string $app, string $key, string $default = '') {
+					return $default;
+				}
+			);
+		return $appConfig;
+	}//end appConfig()
+
+	/**
+	 * The dossiq-shaped case object: a status the schema knows nothing about.
+	 */
+	private function caseObject(string $status = 'in-behandeling'): ObjectEntity {
+		$case = new ObjectEntity();
+		$case->setUuid(self::CASE);
+		$case->setSchema('case');
+		$case->setRegister('1');
+		$case->setObject(['caseType' => 'ct-1', 'status' => $status]);
+		return $case;
+	}//end caseObject()
+
+	/**
+	 * A provider-mode annotation, the shape a delegating schema declares.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function providerAnnotation(): array {
+		return [
+			'field' => 'status',
+			'initial' => ['from' => 'caseType', 'field' => 'initialStatus'],
+			'provider' => self::TAG,
+		];
+	}//end providerAnnotation()
+
+	/**
+	 * Serve the annotation, and answer `find()` with the before-state first
+	 * and the after-state on the engine's re-read.
+	 *
+	 * @param array<string, mixed> $annotation The lifecycle block to serve.
+	 * @param ObjectEntity|null $after What the re-read answers; the before-state when null.
+	 */
+	private function wire(ObjectEntity $before, array $annotation, ?ObjectEntity $after = null): void {
+		$answers = [$before, ($after ?? $before)];
+		$this->objectService->method('find')
+			->willReturnCallback(
+				static function () use (&$answers) {
+					return (array_shift($answers) ?? null);
+				}
+			);
+
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getConfiguration')->willReturn(['x-openregister-lifecycle' => $annotation]);
+		$this->schemaMapper->method('find')->willReturn($schema);
+	}//end wire()
+
+	/**
+	 * Register a provider under the annotation's tag.
+	 */
+	private function provider(): LifecycleActionProviderInterface&MockObject {
+		$provider = $this->createMock(LifecycleActionProviderInterface::class);
+		$this->registry->method('resolve')->with(self::TAG)->willReturn($provider);
+		return $provider;
+	}//end provider()
+
+	/**
+	 * THE DEFECT, pinned. A provider-mode schema declares no `transitions`,
+	 * so before this branch existed the write path fell through to "Transition
+	 * ... is not declared on this schema." and the object never moved. The
+	 * provider is asked instead, with the object payload, the caller, the
+	 * action and the payload it was given.
+	 */
+	public function testTheProviderIsAskedToPerformTheMove(): void {
+		$before = $this->caseObject();
+		$after = $this->caseObject('afgehandeld');
+		$this->wire($before, $this->providerAnnotation(), $after);
+
+		$provider = $this->provider();
+		$provider->expects($this->once())
+			->method('execute')
+			->with(
+				// `id` is stamped on by ObjectEntity::getObject(), and it is
+				// how a provider finds its own record: dossiq's reads
+				// `id`/`uuid`/`@self.id` off exactly this payload.
+				['caseType' => 'ct-1', 'status' => 'in-behandeling', 'id' => self::CASE],
+				'',
+				self::ACTION,
+				['resultTypeId' => 'rt-1']
+			)
+			->willReturn(['status' => 'ok']);
+
+		$result = $this->engine->transition(self::CASE, self::ACTION, ['resultTypeId' => 'rt-1']);
+
+		$this->assertSame($after, $result);
+	}//end testTheProviderIsAskedToPerformTheMove()
+
+	/**
+	 * OPENREGISTER WRITES NOTHING. The provider owns the whole write —
+	 * dossiq's takes a version lock, refuses a closing move with no result,
+	 * writes the status record and dispatches side effects — so a `saveObject()`
+	 * here would be a second, blind write racing the app's own.
+	 */
+	public function testOpenRegisterDoesNotSaveTheObjectItself(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation(), $this->caseObject('afgehandeld'));
+		$this->provider()->method('execute')->willReturn([]);
+
+		$this->objectService->expects($this->never())->method('saveObject');
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testOpenRegisterDoesNotSaveTheObjectItself()
+
+	/**
+	 * The transitioned event still fires, and its `to` is read off the object
+	 * as it was RE-READ — the stored truth — when the provider's report does
+	 * not name one. dossiq's `execute()` answers
+	 * `status`/`statusRecord`/`dispatchedActions`/`version`, so this is the
+	 * ordinary case rather than the fallback.
+	 */
+	public function testTransitionedEventUsesTheReReadStateWhenTheReportIsSilent(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation(), $this->caseObject('afgehandeld'));
+		$this->provider()->method('execute')->willReturn(['status' => 'ok', 'version' => 4]);
+
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with(
+				$this->callback(
+					static function ($event): bool {
+						return $event instanceof ObjectTransitionedEvent
+							&& $event->getAction() === self::ACTION
+							&& $event->getFrom() === 'in-behandeling'
+							&& $event->getTo() === 'afgehandeld';
+					}
+				)
+			);
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testTransitionedEventUsesTheReReadStateWhenTheReportIsSilent()
+
+	/**
+	 * A provider that DOES name its target state in the report has that
+	 * answered, which is the one key OpenRegister reads off the array.
+	 */
+	public function testTransitionedEventPrefersTheReportedTargetState(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation(), $this->caseObject(''));
+		$this->provider()->method('execute')->willReturn(['to' => 'afgehandeld']);
+
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with(
+				$this->callback(
+					static function ($event): bool {
+						return $event instanceof ObjectTransitionedEvent
+							&& $event->getTo() === 'afgehandeld';
+					}
+				)
+			);
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testTransitionedEventPrefersTheReportedTargetState()
+
+	/**
+	 * A REFUSAL STAYS A REFUSAL. The provider says no — a guard refused, the
+	 * case already moved, a closing move carries no result — and that reaches
+	 * the controller as the plain `RuntimeException` it maps to 422, carrying
+	 * the provider's own sentence. Wrapping it would turn "the deadline has
+	 * passed" into "the upstream is down".
+	 */
+	public function testAProviderRefusalSurfacesAsARefusal(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider()->method('execute')
+			->willThrowException(new RuntimeException('De bezwaartermijn is verstreken.'));
+
+		$this->dispatcher->expects($this->never())->method('dispatchTyped');
+
+		try {
+			$this->engine->transition(self::CASE, self::ACTION);
+			$this->fail('Expected the provider refusal to propagate.');
+		} catch (RuntimeException $e) {
+			$this->assertNotInstanceOf(LifecycleProviderException::class, $e);
+			$this->assertSame('De bezwaartermijn is verstreken.', $e->getMessage());
+		}
+	}//end testAProviderRefusalSurfacesAsARefusal()
+
+	/**
+	 * A BREAKAGE STAYS A BREAKAGE, first route: the provider declares its own
+	 * failure with `LifecycleProviderException`, and it reaches the controller
+	 * as that type — 502 — rather than being reclassified as a refused move.
+	 */
+	public function testADeclaredProviderFailureIsNotReclassifiedAsARefusal(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider()->method('execute')
+			->willThrowException(new LifecycleProviderException('workflowTemplate is not valid JSON'));
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('workflowTemplate is not valid JSON');
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testADeclaredProviderFailureIsNotReclassifiedAsARefusal()
+
+	/**
+	 * A BREAKAGE STAYS A BREAKAGE, second route: an unplanned throw — a
+	 * `TypeError`, an `Error` — is wrapped and logged, never reported as a
+	 * refusal. A refusal tells a handler the move was considered and declined;
+	 * this one was never considered at all.
+	 */
+	public function testAnUnplannedProviderThrowIsWrappedAsAFailure(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+		$this->provider()->method('execute')
+			->willThrowException(new \TypeError('Argument #1 must be of type array, null given'));
+
+		$this->logger->expects($this->once())->method('error');
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('could not apply action');
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testAnUnplannedProviderThrowIsWrappedAsAFailure()
+
+	/**
+	 * FAIL CLOSED on an unresolvable tag, on the write path too. Drives a REAL
+	 * registry against empty containers, so the policy is exercised rather
+	 * than restated by a double.
+	 */
+	public function testAnUnregisteredProviderFailsClosedOnTheWritePath(): void {
+		$notFound = new class extends \Exception implements NotFoundExceptionInterface {
+		};
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willThrowException($notFound);
+		$serverContainer = $this->createMock(\OCP\IServerContainer::class);
+		$serverContainer->method('get')->willThrowException($notFound);
+
+		$engine = new TransitionEngine(
+			$this->objectService,
+			$this->schemaMapper,
+			$this->dispatcher,
+			$this->createMock(IUserSession::class),
+			$this->permission(),
+			$this->createMock(RegisterMapper::class),
+			$this->appConfig(),
+			$this->logger,
+			new LifecycleWriteBoundary(new LifecycleActionContext()),
+			new LifecycleActionProviderRegistry($container, $serverContainer, $this->logger)
+		);
+
+		$this->wire($this->caseObject(), $this->providerAnnotation());
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('is not registered');
+
+		$engine->transition(self::CASE, self::ACTION);
+	}//end testAnUnregisteredProviderFailsClosedOnTheWritePath()
+
+	/**
+	 * An object that is gone after the move leaves OpenRegister nothing
+	 * truthful to answer the endpoint with, so it says so as a provider
+	 * failure rather than inventing a stale entity.
+	 */
+	public function testAnObjectThatCannotBeReReadIsAFailure(): void {
+		$before = $this->caseObject();
+		$answers = [$before, null];
+		$this->objectService->method('find')
+			->willReturnCallback(
+				static function () use (&$answers) {
+					return (array_shift($answers) ?? null);
+				}
+			);
+		$schema = $this->createMock(Schema::class);
+		$schema->method('getConfiguration')
+			->willReturn(['x-openregister-lifecycle' => $this->providerAnnotation()]);
+		$this->schemaMapper->method('find')->willReturn($schema);
+
+		$this->provider()->method('execute')->willReturn([]);
+		$this->logger->expects($this->once())->method('error');
+
+		$this->expectException(LifecycleProviderException::class);
+		$this->expectExceptionMessage('could not be read back');
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testAnObjectThatCannotBeReReadIsAFailure()
+
+	/**
+	 * NO WRITE-BOUNDARY DECLARATION, asserted from inside the provider call
+	 * rather than inferred afterwards — a declaration that was made and
+	 * released would be invisible to a check that ran after `execute()`
+	 * returned.
+	 *
+	 * In provider mode there is no named transition for the lifecycle
+	 * listeners to look up: the annotation carries no `transitions` map, so a
+	 * declaration would name them something they cannot resolve while claiming
+	 * OpenRegister is applying it through its own save pipeline. The
+	 * enforcement it supports has moved into the provider, which re-validates
+	 * the move itself.
+	 */
+	public function testNoActionIsDeclaredForTheListenersDuringAProviderWrite(): void {
+		$this->wire($this->caseObject(), $this->providerAnnotation(), $this->caseObject('afgehandeld'));
+
+		$seen = 'unset';
+		$this->provider()->method('execute')
+			->willReturnCallback(
+				function () use (&$seen): array {
+					$seen = $this->actions->declaredFor(uuid: self::CASE);
+					return [];
+				}
+			);
+
+		$this->engine->transition(self::CASE, self::ACTION);
+
+		$this->assertNull($seen);
+	}//end testNoActionIsDeclaredForTheListenersDuringAProviderWrite()
+
+	/**
+	 * STATIC STILL WINS, on the write path exactly as on the read path. A
+	 * schema that grows a provider tag beside the transitions it already had
+	 * keeps applying them, and the provider is not even resolved.
+	 */
+	public function testStaticTransitionsTakePrecedenceOverTheProvider(): void {
+		$this->registry->expects($this->never())->method('resolve');
+
+		$annotation = $this->providerAnnotation();
+		$annotation['transitions'] = [
+			'goedkeuren' => ['from' => ['in-behandeling'], 'to' => 'afgehandeld'],
+		];
+		$this->wire($this->caseObject(), $annotation);
+
+		$saved = $this->caseObject('afgehandeld');
+		$this->objectService->expects($this->once())->method('saveObject')->willReturn($saved);
+
+		$this->assertSame($saved, $this->engine->transition(self::CASE, 'goedkeuren'));
+	}//end testStaticTransitionsTakePrecedenceOverTheProvider()
+
+	/**
+	 * A SCHEMA WITH NO PROVIDER IS UNAFFECTED: the branch is entered only on a
+	 * non-empty `provider` string, so a static schema still refuses an
+	 * undeclared action with the message it always did, and no provider is
+	 * resolved on the way there.
+	 */
+	public function testASchemaWithoutAProviderIsUnaffected(): void {
+		$this->registry->expects($this->never())->method('resolve');
+
+		$this->wire(
+			$this->caseObject(),
+			[
+				'field' => 'status',
+				'transitions' => ['goedkeuren' => ['from' => ['ontvangen'], 'to' => 'afgehandeld']],
+			]
+		);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('is not declared on this schema');
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testASchemaWithoutAProviderIsUnaffected()
+
+	/**
+	 * An EMPTY `provider` string declares no provider, so it must not be
+	 * resolved and must not swallow the graph mode behind it. Pins the
+	 * `trim()` the branch guards on, which is the same guard the read path
+	 * uses.
+	 */
+	public function testAnEmptyProviderStringIsNotAProvider(): void {
+		$this->registry->expects($this->never())->method('resolve');
+
+		$annotation = $this->providerAnnotation();
+		$annotation['provider'] = '   ';
+		$this->wire($this->caseObject(), $annotation);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('is not declared on this schema');
+
+		$this->engine->transition(self::CASE, self::ACTION);
+	}//end testAnEmptyProviderStringIsNotAProvider()
+}//end class


### PR DESCRIPTION
Closes #3679.

Provider mode could offer a lifecycle move and could not take it. `deriveActions()` resolved `provider` and published a timeline; `applyTransition()` had no provider branch, so every click on that timeline came back as `Transition "lc-start" is not declared on this schema.` and the object never moved. This adds the write half.

## What changed

**`LifecycleActionProviderInterface` grows `execute(array $object, string $userId, string $action, array $data): array`.** Same `(object, userId)` prefix as `availableActions()`, with the write's extra arguments appended, so the two read as one call and its variant.

**The provider performs the write. OpenRegister does not.** It resolves the tag, hands over the payload, the caller and the data, and then re-reads. It does not mutate the lifecycle field and never calls `saveObject()` on this path. dossiq's `StatusTransitionService::execute()` re-evaluates guards, takes an optimistic version lock, refuses a closing move with no result, writes the status record and dispatches side effects; a contract that answered "here is the new value, you save it" would strand all of that and race the app's own write.

**The return value is a report, not the object.** Exactly one key is read off it, `to`. When absent, the target state is read off the re-read object's lifecycle field, which is why dossiq can return its existing `status`/`statusRecord`/`dispatchedActions`/`version` array verbatim. Everything the client is answered with comes from the re-read, not from the provider's echo.

**Mode precedence on the write path now mirrors the read path exactly:** static `transitions`, then `provider`, then `graph`. `TransitionEngineGraphTest`'s static-over-graph pin stays green, and a new test pins static-over-provider on the write path too.

**No `declaringAction()` on this path, and not by omission.** The static path declares the named transition so the lifecycle listeners judge the action asked for rather than the first one sharing its from/to pair. In provider mode the annotation carries no `transitions` map, so there is no name for them to look up: a declaration would tell them something they cannot resolve, would claim OpenRegister is applying it through its own save pipeline while the app is writing across several objects, and would hold that claim open for the whole app call rather than around one save. The enforcement it supports has not been lost, it moved into the provider, which re-validates the move with the same reader that answered the read. That is the difference from graph mode, which skips the declaration and has nothing re-checking the move, and is why graph mode is documented as unenforced and this is not. `around()` still frames the write, because `transition()` wraps every mode in it, so an automatic move that follows from this one is still drained.

## Three failures that must not collapse into each other

| what happened | how it is thrown | status |
| --- | --- | --- |
| the provider refused the move | any ordinary `RuntimeException`, passed through unwrapped, message intact | 422 |
| the provider is broken | `LifecycleProviderException`, thrown by the provider, by tag resolution, by wrapping anything that is not a `RuntimeException`, or when the object cannot be re-read | 502 |
| the object is gone | `LifecycleSubjectNotFoundException` (new, extends `RuntimeException`) | 404 |

`LifecycleProviderException` already extends `RuntimeException`, so the engine's `catch (RuntimeException) { throw $e; }` keeps a refusal a refusal and a declared breakage a breakage without reclassifying either, and only an unplanned throw (a `TypeError`, an `Error`) is wrapped and logged. The controller catches the three in narrowing order; a reorder silently collapses one into another, which is what the three new controller tests pin.

**One deliberate behaviour change beyond the provider branch:** a missing object on `POST /transition` answered 422 before this PR, the same status as a refused move, so "someone deleted this case" and "this case cannot move yet" reached a handler identically. It now answers 404, which is what `GET /available-actions` already answered for the same condition. `LifecycleSubjectNotFoundException` extends `RuntimeException`, so REQ-007's "throw `RuntimeException` if not found" still holds literally and every existing catch site is unchanged.

## Verified

- `COMPOSER_PROCESS_TIMEOUT=0 composer check:strict` gives **exit 1**, and the 1 is this box, not this branch. lint, `check:migration-version`, phpcs, phpmd, psalm (`No errors found!`) and phpstan (`[OK] No errors`) are all green; `test:all` ran 20120 tests with 49306 assertions, 0 failures, and exits 1 only on the runner warning `No code coverage driver available`. `phpunit.xml` declares clover and html coverage reports and this machine has neither xdebug nor pcov. The identical suite with `--no-coverage` exits 0. CI has a driver.
- `applyTransition()` crossed phpmd's 100-line threshold when the provider branch landed, so the delegating-mode dispatch is now its own `applyDelegatedTransition()`; phpmd is clean rather than suppressed.
- 16 mutation checks, one per intended behaviour: each breaks the source, reddens the assertion that owns it, and restores to an empty `git diff`. The first one is the defect itself: deleting the provider branch reproduces `Transition "lc-start" is not declared on this schema.` verbatim.
- Not run: CI is the arbiter.

## Inherited findings

The diff check reports 34 inherited phpcs findings in `tests/Unit/Controller/TransitionControllerTest.php` and counts 91 more as new across the two test files; all of them are `RequireNamedParameters` and missing-docblock sniffs on test code, and `phpcs.xml` declares `<file>lib</file>`, so the project's own gate has never scanned `tests/`. The new file matches the style of the neighbour it sits beside. The single finding inside the gate's scope, a `RequireNamedParameters` on the new exception, is fixed.

## What dossiq has to do

`OCA\Dossiq\Lifecycle\CaseActionProvider` implements this interface and will fatal on the new method until it adds one. It is a thin delegate:

```php
public function execute(array $object, string $userId, string $action, array $data): array {
    $caseId = $this->caseIdOf(object: $object);
    // … refuse with a RuntimeException when the id is missing,
    //   throw LifecycleProviderException when the engine itself breaks …
    return $this->transitionEngine->execute(
        caseId: $caseId,
        transitionId: $action,
        comment: ($data['comment'] ?? null),
        userId: ($userId !== '' ? $userId : null),
        resultTypeId: ($data['resultTypeId'] ?? null),
    );
}
```

`StatusTransitionService::execute()` already returns an array and already throws `GuardFailedException extends RuntimeException` for a refusal, so both halves of the error contract fall out of what dossiq has. The one thing to check on its side is that a broken lookup (`case_not_found` from a storage failure rather than a real deletion, an unparseable workflowTemplate) is raised as `LifecycleProviderException` rather than a bare `RuntimeException`, or it will read to a user as a refused move instead of a breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)