### PR TITLE
fix: the per-file repairs left in the dark Database, Integration and Service suites (wave 5)

### DIFF
--- a/lib/Db/AuditTrailMapper.php
+++ b/lib/Db/AuditTrailMapper.php
@@ -1990,6 +1990,8 @@ class AuditTrailMapper extends QBMapper {
 	 * @return int Number of audit trails updated
 	 *
 	 * @throws \Exception Database operation exceptions
+	 *
+	 * @spec openspec/specs/audit-trail-immutable/spec.md#requirement-the-audit-trail-must-support-minimum-10-year-retention
 	 */
 	public function setExpiryDate(int $retentionMs): int {
 		try {
@@ -1999,14 +2001,19 @@ class AuditTrailMapper extends QBMapper {
 			// Get the query builder.
 			$qb = $this->db->getQueryBuilder();
 
+			// DATE_ADD is MySQL and MariaDB only, so the interval is spelled per
+			// platform. SearchTrailMapper::setExpiryDate() already learned this
+			// the hard way when the hourly LogCleanUpTask started calling it; the
+			// audit-trail twin kept the MySQL-only expression, which would throw
+			// on every PostgreSQL install the moment anything calls it.
+			$expiresExpression = sprintf('DATE_ADD(created, INTERVAL %d SECOND)', $retentionSeconds);
+			if ($this->db->getDatabasePlatform() instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {
+				$expiresExpression = sprintf("created + INTERVAL '%d seconds'", $retentionSeconds);
+			}
+
 			// Update audit trails that don't have an expiry date set.
 			$qb->update($this->getTableName())
-				->set(
-					'expires',
-					$qb->createFunction(
-						sprintf('DATE_ADD(created, INTERVAL %d SECOND)', $retentionSeconds)
-					)
-				)
+				->set('expires', $qb->createFunction($expiresExpression))
 				->where($qb->expr()->isNull('expires'));
 
 			// Execute the update and return number of affected rows.

--- a/lib/Service/DashboardService.php
+++ b/lib/Service/DashboardService.php
@@ -412,9 +412,9 @@ class DashboardService {
 	 *
 	 * @return int[] Array containing counts of processed and failed objects
 	 *
-	 * @psalm-return array{processed: 0|1|2, failed: 0|1|2}
+	 * @psalm-return array{processed: int, failed: int}
 	 *
-	 * @spec openspec/changes/retrofit-2026-05-24-b-svc-compute-profile-org/tasks.md#task-5
+	 * @spec openspec/specs/built-in-dashboards/spec.md#requirement-dashboardservice-must-assemble-or-canned-statistics-and-chart-payloads-with-fail-soft-semantics
 	 */
 	public function recalculateSizes(?int $registerId = null, ?int $schemaId = null): array {
 		$result = [
@@ -423,31 +423,27 @@ class DashboardService {
 		];
 
 		try {
-			// Build filters array based on provided IDs.
-			$filters = [];
-			if ($registerId !== null) {
-				$filters['register'] = $registerId;
-			}
-
-			if ($schemaId !== null) {
-				$filters['schema'] = $schemaId;
-			}
-
-			// Get all relevant objects.
-			$objects = $this->objectMapper->findAll(filters: $filters);
-
-			// Update each object to trigger size recalculation.
-			foreach ($objects as $object) {
-				try {
-					$this->objectMapper->update($object);
-					$result['processed']++;
-				} catch (Exception $e) {
-					$this->logger->error(
-						message: '[DashboardService] Failed to update object ' . $object->getId() . ': ' . $e->getMessage(),
-						context: ['file' => __FILE__, 'line' => __LINE__]
-					);
-					$result['failed']++;
+			// A magic table is one table per register+schema pair, so there is no
+			// single object table to filter. MagicMapper::findAll() says so by
+			// requiring the register and schema ENTITIES and answering [] (with a
+			// warning) when it does not get them: this method passed
+			// ['register' => id, 'schema' => id] as FILTERS and nothing else, so
+			// it processed zero objects on every install while reporting success.
+			// Walk the pairs instead, narrowed by whichever id the caller named.
+			foreach ($this->objectMapper->getAllRegisterSchemaPairs() as $pair) {
+				if ($registerId !== null && (int)$pair['registerId'] !== $registerId) {
+					continue;
 				}
+
+				if ($schemaId !== null && (int)$pair['schemaId'] !== $schemaId) {
+					continue;
+				}
+
+				$this->recalculateSizesForPair(
+					registerId: (int)$pair['registerId'],
+					schemaId: (int)$pair['schemaId'],
+					result: $result
+				);
 			}
 
 			return $result;
@@ -459,6 +455,54 @@ class DashboardService {
 			throw new Exception('Failed to recalculate sizes: ' . $e->getMessage());
 		}//end try
 	}//end recalculateSizes()
+
+	/**
+	 * Re-save every object of one register+schema pair, counting the outcome.
+	 *
+	 * Split out of {@see self::recalculateSizes()} so the pair walk stays
+	 * readable. An unresolvable pair is counted as one failure and logged rather
+	 * than taking the whole run down: a stale magic table whose register or
+	 * schema row is gone must not stop the rest from being recalculated.
+	 *
+	 * @param int   $registerId The register of the pair.
+	 * @param int   $schemaId   The schema of the pair.
+	 * @param array $result     The running processed/failed tally, by reference.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/built-in-dashboards/spec.md#requirement-dashboardservice-must-assemble-or-canned-statistics-and-chart-payloads-with-fail-soft-semantics
+	 */
+	private function recalculateSizesForPair(int $registerId, int $schemaId, array &$result): void {
+		try {
+			$register = $this->registerMapper->find($registerId, _rbac: false, _multitenancy: false);
+			$schema = $this->schemaMapper->find($schemaId, _rbac: false, _multitenancy: false);
+		} catch (Exception $e) {
+			$this->logger->error(
+				message: '[DashboardService] Skipping pair ' . $registerId . '/' . $schemaId . ': ' . $e->getMessage(),
+				context: ['file' => __FILE__, 'line' => __LINE__]
+			);
+			$result['failed']++;
+			return;
+		}
+
+		$objects = $this->objectMapper->findAllInRegisterSchemaTable(
+			register: $register,
+			schema: $schema
+		);
+
+		foreach ($objects as $object) {
+			try {
+				$this->objectMapper->update($object, $register, $schema);
+				$result['processed']++;
+			} catch (Exception $e) {
+				$this->logger->error(
+					message: '[DashboardService] Failed to update object ' . $object->getId() . ': ' . $e->getMessage(),
+					context: ['file' => __FILE__, 'line' => __LINE__]
+				);
+				$result['failed']++;
+			}
+		}
+	}//end recalculateSizesForPair()
 
 	/**
 	 * Recalculate sizes for audit trail logs in specified registers and/or schemas

--- a/lib/Service/Settings/CacheSettingsHandler.php
+++ b/lib/Service/Settings/CacheSettingsHandler.php
@@ -501,9 +501,15 @@ class CacheSettingsHandler {
 			$objectCacheService->clearCache();
 			$afterStats = $objectCacheService->getStats();
 
+			// CacheHandler::getStats() reports cache_size, query_cache_size and
+			// name_cache_size, and never an `entries` key. Reading `entries`
+			// produced two "Undefined array key" warnings per call and a cleared
+			// count of 0 - 0, so the admin action always reported clearing
+			// nothing. clearCache() empties all three in-memory caches, so all
+			// three are what it cleared.
 			return [
 				'service' => 'object',
-				'cleared' => $beforeStats['entries'] - $afterStats['entries'],
+				'cleared' => ($this->countCacheEntries(stats: $beforeStats) - $this->countCacheEntries(stats: $afterStats)),
 				'before' => $beforeStats,
 				'after' => $afterStats,
 				'success' => true,
@@ -517,6 +523,21 @@ class CacheSettingsHandler {
 			];
 		}//end try
 	}//end clearObjectCache()
+
+	/**
+	 * Total in-memory entries a CacheHandler stats payload reports.
+	 *
+	 * @param array $stats A {@see \OCA\OpenRegister\Service\Object\CacheHandler::getStats()} payload.
+	 *
+	 * @return int The object, query and name cache sizes added together.
+	 *
+	 * @spec exclude Arithmetic over a stats payload; the behaviour it feeds is covered by clearObjectCache().
+	 */
+	private function countCacheEntries(array $stats): int {
+		return ((int)($stats['cache_size'] ?? 0)
+			+ (int)($stats['query_cache_size'] ?? 0)
+			+ (int)($stats['name_cache_size'] ?? 0));
+	}//end countCacheEntries()
 
 	/**
 	 * Clear object names cache specifically

--- a/tests/Db/AuditTrailMapperIntegrationTest.php
+++ b/tests/Db/AuditTrailMapperIntegrationTest.php
@@ -151,7 +151,10 @@ class AuditTrailMapperIntegrationTest extends TestCase {
 		$entity->setSchema((string)$schema->getId());
 		$entity->setObject(['name' => 'phpunit-test-' . uniqid()]);
 
-		$result = $this->objectMapper->insertEntity($entity);
+		// insertEntity() went with the blob objects table. MagicMapper::insert()
+		// is the successor and needs the register and schema the magic table is
+		// named after.
+		$result = $this->objectMapper->insert($entity, $register, $schema);
 		$this->createdObjectIds[] = $result->getId();
 
 		return $result;
@@ -534,12 +537,12 @@ class AuditTrailMapperIntegrationTest extends TestCase {
 	// =========================================================================
 
 	public function testSetExpiryDateUpdatesNullExpires(): void {
-		// setExpiryDate uses DATE_ADD which is MySQL-only; skip on PostgreSQL
+		// This used to skip on PostgreSQL, because setExpiryDate() wrote the
+		// MySQL-only DATE_ADD. The skip hid a portability defect rather than a
+		// platform limit: its SearchTrailMapper twin had already been taught to
+		// spell the interval per platform, and this one had not. The method does
+		// it now, so the test runs on both backends.
 		$db = \OC::$server->get(\OCP\IDBConnection::class);
-		$platform = $db->getDatabasePlatform();
-		if (stripos(get_class($platform), 'PostgreSQL') !== false) {
-			$this->markTestSkipped('setExpiryDate uses DATE_ADD which is not supported on PostgreSQL');
-		}
 
 		// Create an audit trail without an expiry date
 		$qb = $db->getQueryBuilder();

--- a/tests/Db/MagicRbacHandlerIntegrationTest.php
+++ b/tests/Db/MagicRbacHandlerIntegrationTest.php
@@ -800,46 +800,38 @@ class MagicRbacHandlerIntegrationTest extends TestCase {
 	// =========================================================================
 	// Fail-closed SQL match evaluation on null-resolved dynamic variables (#1953).
 	//
-	// 🔴 THESE THREE CANNOT PASS UNDER PHPUNIT, AND THAT IS THE FINDING, NOT A
-	// FLAKE. They were written on 2026-05-27 (#1959). On 2026-06-10 commit
-	// 4496c7f5 added a bypass to MagicRbacHandler::applyRbacFilters():
+	// THE RULE: when a `match` rule's dynamic variable ($organisation, $userId,
+	// $now) resolves to null, the SQL path MUST emit the impossible predicate
+	// (1 = 0) for that property rather than dropping it from the AND. Dropping it
+	// widens the rule, which is how an object leaked on LIST while the PHP/find
+	// path (ConditionMatcher) denied it.
 	//
-	//     if ($user === null && PHP_SAPI === 'cli') { return; }
+	// These three used to drive `searchObjectsInRegisterSchemaTable()` and assert
+	// on rows, and they could never pass under PHPUnit. That path emits through
+	// `applyRbacFilters()`, which returns early for `$user === null &&
+	// PHP_SAPI === 'cli'` (4496c7f5, 2026-06-10): inside any cli process an
+	// anonymous caller skips RBAC filtering entirely, so the branch under test was
+	// unreachable and the rows always came back. Measured over HTTP on 2026-09-12
+	// on this same schema shape, the web path does fail closed: anonymous GET
+	// returned total 0 where admin saw 1.
 	//
-	// so in ANY cli process an anonymous caller skips RBAC filtering entirely
-	// and every row comes back. PHPUnit is a cli process, so the branch these
-	// tests exercise is unreachable here and they have failed silently ever
-	// since, in a suite CI never ran.
-	//
-	// The rule they assert still holds where it matters. Measured over HTTP on
-	// 2026-09-12 against this exact schema shape (public match rule with
-	// `_organisation` => '$organisation' and one published row): an anonymous
-	// GET returned `total: 0`, the same read as admin returned 1. The web path
-	// fails closed; the cli path does not ask.
-	//
-	// Left failing on purpose rather than skipped: a reason-bearing skip here
-	// would read as "covered" in a suite that is about to become a gate. The
-	// fix belongs in production code, where "no session" alone should stop
-	// meaning "trusted" inside a cli process. OpenRegister already has the
-	// explicit mechanism for that in
-	// {@see \OCA\OpenRegister\Service\SystemOperationContext}, whose own
-	// docblock says the `PHP_SAPI === 'cli'` trust "covers occ and CLI cron
-	// only" and which exists to scope that trust to named code blocks.
-	//
-	// When a `match` rule's dynamic variable ($organisation/$userId/$now)
-	// resolves to null, the SQL/list path MUST emit an impossible predicate
-	// (1 = 0) for that property rather than dropping it from the AND. This makes
-	// the LIST path agree with the PHP/find path (ConditionMatcher), which
-	// already fails closed on null dynamic values. These tests run as anonymous
-	// (the genuine null-$organisation case) so $organisation cannot resolve.
+	// So they now assert the rule on `buildRbacConditionsSql()`, the emitter for
+	// the UNION/multi-table path. It is production code, it carries no cli
+	// carve-out, and it is the same rule: an anonymous caller in a cli process
+	// reaches it exactly as an anonymous web caller does. What stays uncovered
+	// from a cli process is the single-table QueryBuilder emitter, because of that
+	// early return. Narrowing the cli trust is a product decision and not a test
+	// repair: `SystemOperationContext` exists for precisely that scoping, but
+	// cron.php does not define OC_CONSOLE, so a naive narrowing would blind every
+	// background job instead. Raised in the PR rather than changed here.
 	// =========================================================================
 
-	public function testListFailsClosedOnMultiConditionMatchWithNullOrganisation(): void {
-		// Multi-condition public match rule: a static `status` predicate AND a
-		// dynamic `_organisation` => '$organisation' predicate. As anonymous,
-		// $organisation resolves to null, so the rule must grant NO rows even
-		// though the static predicate matches the inserted object.
-		$register = $this->createTestRegister();
+	/**
+	 * A null-resolved dynamic predicate denies, and does not silently drop.
+	 *
+	 * @return void
+	 */
+	public function testSqlFailsClosedOnMultiConditionMatchWithNullOrganisation(): void {
 		$schema = $this->createTestSchema([
 			'read' => [
 				[
@@ -852,87 +844,65 @@ class MagicRbacHandlerIntegrationTest extends TestCase {
 			],
 		]);
 
-		$this->mapper->ensureTableForRegisterSchema($register, $schema);
-		$this->trackTable($register, $schema);
+		$result = $this->rbacHandler->buildRbacConditionsSql(schema: $schema, action: 'read');
+		$sql = implode(' OR ', $result['conditions']);
 
-		// Object satisfies the static predicate (status=published) but the
-		// $organisation predicate cannot be satisfied for an anonymous caller.
-		$this->insertTestObject($register, $schema, ['name' => 'Leaky', 'status' => 'published', 'age' => 1]);
-
-		$results = $this->mapper->searchObjectsInRegisterSchemaTable(
-			['_multitenancy' => false],
-			$register,
-			$schema
+		$this->assertFalse($result['bypass'], 'an anonymous caller MUST NOT bypass RBAC');
+		$this->assertStringContainsString(
+			'1 = 0',
+			$sql,
+			'the null-resolved $organisation predicate MUST become the impossible predicate'
 		);
-
-		// Pre-fix: the null $organisation predicate was DROPPED, leaving only
-		// status=published, so the object leaked on LIST. Post-fix the impossible
-		// predicate (1 = 0) is ANDed in, so LIST returns nothing — matching the
-		// PHP/find verdict.
-		$this->assertIsArray($results);
-		$this->assertEmpty(
-			$results,
-			'Multi-condition match with null-resolved $organisation MUST deny on LIST (no silent drop)'
+		$this->assertStringContainsString(
+			"status = 'published'",
+			$sql,
+			'the static half of the rule MUST still be emitted, ANDed with the denial'
 		);
-	}
+	}//end testSqlFailsClosedOnMultiConditionMatchWithNullOrganisation()
 
-	public function testListFailsClosedOnSingleConditionMatchWithNullOrganisation(): void {
-		// Single-condition match on a null-resolving dynamic variable: LIST must
-		// also deny (parity with find), confirming the impossible predicate is
-		// emitted rather than the whole match being dropped.
-		$register = $this->createTestRegister();
+	/**
+	 * A rule whose ONLY predicate resolves to null denies outright.
+	 *
+	 * @return void
+	 */
+	public function testSqlFailsClosedOnSingleConditionMatchWithNullOrganisation(): void {
 		$schema = $this->createTestSchema([
 			'read' => [
 				['group' => 'public', 'match' => ['_organisation' => '$organisation']],
 			],
 		]);
 
-		$this->mapper->ensureTableForRegisterSchema($register, $schema);
-		$this->trackTable($register, $schema);
+		$result = $this->rbacHandler->buildRbacConditionsSql(schema: $schema, action: 'read');
 
-		$this->insertTestObject($register, $schema, ['name' => 'SingleLeaky', 'status' => 'x', 'age' => 1]);
-
-		$results = $this->mapper->searchObjectsInRegisterSchemaTable(
-			['_multitenancy' => false],
-			$register,
-			$schema
+		$this->assertFalse($result['bypass']);
+		$this->assertStringContainsString(
+			'1 = 0',
+			implode(' OR ', $result['conditions']),
+			'a match rule that resolves to nothing MUST deny, not match everything'
 		);
+	}//end testSqlFailsClosedOnSingleConditionMatchWithNullOrganisation()
 
-		$this->assertIsArray($results);
-		$this->assertEmpty(
-			$results,
-			'Single-condition match with null-resolved $organisation MUST deny on LIST'
-		);
-	}
-
-	public function testResolvableMatchRuleStillReturnsRowsOnList(): void {
-		// Guard against over-denial: a match rule whose predicates DO resolve
-		// (a static-only public match) must still return its rows on LIST. The
-		// fail-closed change introduces no new denials for resolvable rules.
-		$register = $this->createTestRegister();
+	/**
+	 * Guard against over-denial: a resolvable rule keeps granting.
+	 *
+	 * @return void
+	 */
+	public function testSqlKeepsGrantingOnAFullyResolvableMatchRule(): void {
 		$schema = $this->createTestSchema([
 			'read' => [
 				['group' => 'public', 'match' => ['status' => 'published']],
 			],
 		]);
 
-		$this->mapper->ensureTableForRegisterSchema($register, $schema);
-		$this->trackTable($register, $schema);
+		$result = $this->rbacHandler->buildRbacConditionsSql(schema: $schema, action: 'read');
+		$sql = implode(' OR ', $result['conditions']);
 
-		$this->insertTestObject($register, $schema, ['name' => 'Visible', 'status' => 'published', 'age' => 1]);
-		$this->insertTestObject($register, $schema, ['name' => 'Hidden', 'status' => 'draft', 'age' => 1]);
-
-		$results = $this->mapper->searchObjectsInRegisterSchemaTable(
-			['_multitenancy' => false],
-			$register,
-			$schema
+		$this->assertStringContainsString("status = 'published'", $sql);
+		$this->assertStringNotContainsString(
+			'1 = 0',
+			$sql,
+			'a rule whose predicates all resolve MUST NOT pick up a denial'
 		);
+	}//end testSqlKeepsGrantingOnAFullyResolvableMatchRule()
 
-		$this->assertIsArray($results);
-		$this->assertCount(
-			1,
-			$results,
-			'A fully-resolvable static match rule MUST still return its matching rows (no new denials)'
-		);
-	}
 }

--- a/tests/Db/OrganisationMapperIntegrationTest.php
+++ b/tests/Db/OrganisationMapperIntegrationTest.php
@@ -148,10 +148,15 @@ class OrganisationMapperIntegrationTest extends TestCase {
 	}
 
 	public function testFindAllRespectsOffset(): void {
+		// This used to skip when the instance happened to hold fewer than two
+		// organisations, which made it a test that only ran on a dirty database.
+		// The fixture it needs costs two lines, and the sibling limit test
+		// already creates them.
+		$this->createTestOrganisation();
+		$this->createTestOrganisation();
+
 		$all = $this->mapper->findAll(10000, 0);
-		if (count($all) < 2) {
-			$this->markTestSkipped('Need at least 2 organisations for offset test');
-		}
+		$this->assertGreaterThanOrEqual(2, count($all));
 
 		$offset = $this->mapper->findAll(10000, 1);
 		$this->assertCount(count($all) - 1, $offset);

--- a/tests/Db/RegisterMapperIntegrationTest.php
+++ b/tests/Db/RegisterMapperIntegrationTest.php
@@ -81,12 +81,12 @@ class RegisterMapperIntegrationTest extends TestCase {
 	}
 
 	public function testFindAllRespectsOffset(): void {
-		$all = $this->mapper->findAll(null, null, [], [], [], [], null, false, false);
+		$all = $this->mapper->findAll(null, null, [], [], [], _rbac: false, _multitenancy: false);
 		if (count($all) < 2) {
 			$this->markTestSkipped('Need at least 2 registers for offset test');
 		}
 
-		$offset = $this->mapper->findAll(null, 1, [], [], [], [], null, false, false);
+		$offset = $this->mapper->findAll(null, 1, [], [], [], _rbac: false, _multitenancy: false);
 		$this->assertCount(count($all) - 1, $offset);
 	}
 
@@ -99,8 +99,6 @@ class RegisterMapperIntegrationTest extends TestCase {
 			['source' => 'internal'],
 			[],
 			[],
-			[],
-			null,
 			false,
 			false
 		);
@@ -118,8 +116,6 @@ class RegisterMapperIntegrationTest extends TestCase {
 			['deleted' => 'IS NULL'],
 			[],
 			[],
-			[],
-			null,
 			false,
 			false
 		);
@@ -134,8 +130,6 @@ class RegisterMapperIntegrationTest extends TestCase {
 			['source' => 'IS NOT NULL'],
 			[],
 			[],
-			[],
-			null,
 			false,
 			false
 		);
@@ -197,7 +191,6 @@ class RegisterMapperIntegrationTest extends TestCase {
 
 		$results = $this->mapper->findMultiple(
 			[$r1->getId(), $r2->getId()],
-			null,
 			false,
 			false
 		);
@@ -209,7 +202,6 @@ class RegisterMapperIntegrationTest extends TestCase {
 		$r1 = $this->createTestRegister();
 		$results = $this->mapper->findMultiple(
 			[$r1->getId(), 999999999],
-			null,
 			false,
 			false
 		);
@@ -346,7 +338,6 @@ class RegisterMapperIntegrationTest extends TestCase {
 
 		$schemas = $this->mapper->getSchemasByRegisterId(
 			$register->getId(),
-			null,
 			false,
 			false
 		);

--- a/tests/Db/SchemaMapperIntegrationTest.php
+++ b/tests/Db/SchemaMapperIntegrationTest.php
@@ -81,17 +81,17 @@ class SchemaMapperIntegrationTest extends TestCase {
 	}
 
 	public function testFindAllRespectsLimit(): void {
-		$results = $this->mapper->findAll(2, 0, [], [], [], [], null, false, false);
+		$results = $this->mapper->findAll(2, 0, [], [], [], [], _rbac: false, _multitenancy: false);
 		$this->assertLessThanOrEqual(2, count($results));
 	}
 
 	public function testFindAllRespectsOffset(): void {
-		$all = $this->mapper->findAll(null, null, [], [], [], [], null, false, false);
+		$all = $this->mapper->findAll(null, null, [], [], [], [], _rbac: false, _multitenancy: false);
 		if (count($all) < 2) {
 			$this->markTestSkipped('Need at least 2 schemas for offset test');
 		}
 
-		$offset = $this->mapper->findAll(null, 1, [], [], [], [], null, false, false);
+		$offset = $this->mapper->findAll(null, 1, [], [], [], [], _rbac: false, _multitenancy: false);
 		$this->assertCount(count($all) - 1, $offset);
 	}
 
@@ -105,7 +105,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 			[],
 			[],
 			[],
-			null,
 			false,
 			false
 		);
@@ -121,7 +120,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 			[],
 			[],
 			[],
-			null,
 			false,
 			false
 		);
@@ -138,7 +136,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 			[],
 			[],
 			[],
-			null,
 			false,
 			false
 		);
@@ -152,7 +149,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 
 	public function testFindById(): void {
 		$schema = $this->createTestSchema();
-		$found = $this->mapper->find($schema->getId(), [], null, false, false);
+		$found = $this->mapper->find($schema->getId(), _extend: [], _rbac: false, _multitenancy: false);
 
 		$this->assertInstanceOf(Schema::class, $found);
 		$this->assertSame($schema->getId(), $found->getId());
@@ -160,7 +157,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 
 	public function testFindByUuid(): void {
 		$schema = $this->createTestSchema();
-		$found = $this->mapper->find($schema->getUuid(), [], null, false, false);
+		$found = $this->mapper->find($schema->getUuid(), _extend: [], _rbac: false, _multitenancy: false);
 
 		$this->assertSame($schema->getId(), $found->getId());
 	}
@@ -170,22 +167,22 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$slug = $schema->getSlug();
 		$this->assertNotNull($slug);
 
-		$found = $this->mapper->find($slug, [], null, false, false);
+		$found = $this->mapper->find($slug, _extend: [], _rbac: false, _multitenancy: false);
 		$this->assertSame($schema->getId(), $found->getId());
 	}
 
 	public function testFindNonExistentThrowsException(): void {
 		$this->expectException(\OCP\AppFramework\Db\DoesNotExistException::class);
-		$this->mapper->find(999999999, [], null, false, false);
+		$this->mapper->find(999999999, _extend: [], _rbac: false, _multitenancy: false);
 	}
 
 	public function testFindCacheHit(): void {
 		$schema = $this->createTestSchema();
 
 		// First call populates cache
-		$found1 = $this->mapper->find($schema->getId(), [], null, false, false);
+		$found1 = $this->mapper->find($schema->getId(), _extend: [], _rbac: false, _multitenancy: false);
 		// Second call should hit cache
-		$found2 = $this->mapper->find($schema->getId(), [], null, false, false);
+		$found2 = $this->mapper->find($schema->getId(), _extend: [], _rbac: false, _multitenancy: false);
 
 		$this->assertSame($found1->getId(), $found2->getId());
 	}
@@ -194,9 +191,9 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$schema = $this->createTestSchema();
 
 		// First call by ID populates cache (also caches by uuid and slug)
-		$found1 = $this->mapper->find($schema->getId(), [], null, false, false);
+		$found1 = $this->mapper->find($schema->getId(), _extend: [], _rbac: false, _multitenancy: false);
 		// This should hit cache via UUID
-		$found2 = $this->mapper->find($schema->getUuid(), [], null, false, false);
+		$found2 = $this->mapper->find($schema->getUuid(), _extend: [], _rbac: false, _multitenancy: false);
 
 		$this->assertSame($found1->getId(), $found2->getId());
 	}
@@ -204,7 +201,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 	public function testFindWithNonNumericId(): void {
 		$schema = $this->createTestSchema();
 		// Find by UUID (non-numeric) to exercise the else branch
-		$found = $this->mapper->find($schema->getUuid(), [], null, false, false);
+		$found = $this->mapper->find($schema->getUuid(), _extend: [], _rbac: false, _multitenancy: false);
 		$this->assertSame($schema->getId(), $found->getId());
 	}
 
@@ -216,24 +213,16 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$schema = $this->createTestSchema();
 		$slug = $schema->getSlug();
 
-		$results = $this->mapper->findBySlug($slug, 10, 0, null, false, false);
+		$results = $this->mapper->findBySlug($slug, 10, 0, _rbac: false, _multitenancy: false);
 		$this->assertIsArray($results);
 		$this->assertNotEmpty($results);
 		$this->assertSame($slug, $results[0]->getSlug());
 	}
 
 	public function testFindBySlugNoResults(): void {
-		$results = $this->mapper->findBySlug('nonexistent-slug-' . uniqid(), 10, 0, null, false, false);
+		$results = $this->mapper->findBySlug('nonexistent-slug-' . uniqid(), 10, 0, _rbac: false, _multitenancy: false);
 		$this->assertIsArray($results);
 		$this->assertEmpty($results);
-	}
-
-	public function testFindBySlugWithPublishedParam(): void {
-		$schema = $this->createTestSchema();
-		$slug = $schema->getSlug();
-
-		$results = $this->mapper->findBySlug($slug, 10, 0, true, false, false);
-		$this->assertIsArray($results);
 	}
 
 	// =========================================================================
@@ -246,7 +235,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 
 		$results = $this->mapper->findMultiple(
 			[$s1->getId(), $s2->getId()],
-			null,
 			false,
 			false
 		);
@@ -258,7 +246,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$s1 = $this->createTestSchema();
 		$results = $this->mapper->findMultiple(
 			[$s1->getId(), 999999999],
-			null,
 			false,
 			false
 		);
@@ -267,7 +254,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 	}
 
 	public function testFindMultipleEmptyArray(): void {
-		$results = $this->mapper->findMultiple([], null, false, false);
+		$results = $this->mapper->findMultiple([], _rbac: false, _multitenancy: false);
 		$this->assertIsArray($results);
 		$this->assertEmpty($results);
 	}
@@ -631,8 +618,12 @@ class SchemaMapperIntegrationTest extends TestCase {
 
 		$facets = $schema->getFacets();
 		$this->assertArrayHasKey('when', $facets['object_fields']);
-		// date-time format maps to terms facet type (the type is 'string')
-		$this->assertSame('terms', $facets['object_fields']['when']['type']);
+		// A date or date-time FORMAT is a date_histogram, whatever the JSON type
+		// says: Schema::determineFacetType() has read `format` before `type`
+		// since 1367ae337 (2025-09-02), and the date-named-property test two
+		// above asserts the same thing. The old expectation of 'terms' was the
+		// test disagreeing with its own neighbour.
+		$this->assertSame('date_histogram', $facets['object_fields']['when']['type']);
 	}
 
 	public function testCreateFromArrayGeneratesFacetForExplicitFacetableProperty(): void {
@@ -1087,7 +1078,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 		]);
 
 		// Re-fetch to get the resolved schema with merged properties
-		$resolvedChild = $this->mapper->find($child->getId(), [], null, false, false);
+		$resolvedChild = $this->mapper->find($child->getId(), _extend: [], _rbac: false, _multitenancy: false);
 
 		$result = $this->mapper->getPropertySourceMetadata($resolvedChild);
 		$this->assertIsArray($result);
@@ -1121,7 +1112,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 		]);
 
 		// When we find the child, the resolved schema should have both properties
-		$resolved = $this->mapper->find($child->getId(), [], null, false, false);
+		$resolved = $this->mapper->find($child->getId(), _extend: [], _rbac: false, _multitenancy: false);
 		$props = $resolved->getProperties();
 
 		$this->assertArrayHasKey('parentField', $props);
@@ -1144,7 +1135,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 			],
 		]);
 
-		$resolved = $this->mapper->find($child->getId(), [], null, false, false);
+		$resolved = $this->mapper->find($child->getId(), _extend: [], _rbac: false, _multitenancy: false);
 		$required = $resolved->getRequired();
 
 		$this->assertContains('parentField', $required);
@@ -1192,7 +1183,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 			[],
 			[],
 			[],
-			null,
 			false,
 			false
 		);
@@ -1269,13 +1259,30 @@ class SchemaMapperIntegrationTest extends TestCase {
 	// Slug uniqueness tests
 	// =========================================================================
 
-	public function testCreateSchemasWithSameTitleThrowsUniqueConstraint(): void {
+	/**
+	 * Two schemas may carry the same slug, and both stay retrievable.
+	 *
+	 * This asserted a unique-constraint violation. Version1Date20260726000000
+	 * (2026-07-26) dropped `schemas_org_app_slug_unique` on purpose: schemas are
+	 * many-to-many with registers, so "unique within a register's set" cannot be
+	 * a single-table index, and the invariant moved to the service layer
+	 * (ImportHandler::importSchema). A second schema with the same title is now
+	 * an ordinary row, so that is what this pins.
+	 *
+	 * @return void
+	 */
+	public function testTwoSchemasMayShareASlug(): void {
 		$title = 'Duplicate Title Schema';
-		$s1 = $this->createTestSchema(['title' => $title]);
-		$this->assertNotNull($s1->getSlug());
+		$first = $this->createTestSchema(['title' => $title]);
+		$second = $this->createTestSchema(['title' => $title]);
 
-		$this->expectException(\Exception::class);
-		$this->createTestSchema(['title' => $title]);
+		$this->assertSame($first->getSlug(), $second->getSlug());
+		$this->assertNotSame($first->getId(), $second->getId());
+
+		$bySlug = $this->mapper->findBySlug($first->getSlug(), 10, 0, _rbac: false, _multitenancy: false);
+		$ids = array_map(static fn ($schema): int => (int)$schema->getId(), $bySlug);
+		$this->assertContains((int)$first->getId(), $ids);
+		$this->assertContains((int)$second->getId(), $ids);
 	}
 
 	// =========================================================================
@@ -1286,8 +1293,8 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$this->createTestSchema();
 		$this->createTestSchema();
 
-		$all = $this->mapper->findAll(null, null, [], [], [], [], null, false, false);
-		$limited = $this->mapper->findAll(1, 0, [], [], [], [], null, false, false);
+		$all = $this->mapper->findAll(null, null, [], [], [], [], _rbac: false, _multitenancy: false);
+		$limited = $this->mapper->findAll(1, 0, [], [], [], [], _rbac: false, _multitenancy: false);
 
 		$this->assertCount(1, $limited);
 		$this->assertGreaterThanOrEqual(2, count($all));
@@ -1301,7 +1308,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$schema = $this->createTestSchema();
 		$slug = $schema->getSlug();
 
-		$results = $this->mapper->findBySlug($slug, 1, 0, null, false, false);
+		$results = $this->mapper->findBySlug($slug, 1, 0, _rbac: false, _multitenancy: false);
 		$this->assertIsArray($results);
 		$this->assertLessThanOrEqual(1, count($results));
 	}
@@ -1310,7 +1317,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$schema = $this->createTestSchema();
 		$slug = $schema->getSlug();
 
-		$results = $this->mapper->findBySlug($slug, 10, 1, null, false, false);
+		$results = $this->mapper->findBySlug($slug, 10, 1, _rbac: false, _multitenancy: false);
 		$this->assertIsArray($results);
 		$this->assertEmpty($results);
 	}
@@ -1454,7 +1461,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 			[],
 			[],
 			[],
-			null,
 			false,
 			false
 		);
@@ -1471,7 +1477,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$slug = $schema->getSlug();
 		$this->assertNotNull($slug);
 
-		$found = $this->mapper->find(strtoupper($slug), [], null, false, false);
+		$found = $this->mapper->find(strtoupper($slug), _extend: [], _rbac: false, _multitenancy: false);
 		$this->assertSame($schema->getId(), $found->getId());
 	}
 
@@ -1517,16 +1523,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 	}
 
 	// =========================================================================
-	// find with published parameter
-	// =========================================================================
-
-	public function testFindWithPublishedBypass(): void {
-		$schema = $this->createTestSchema();
-		$found = $this->mapper->find($schema->getId(), [], true, false, false);
-		$this->assertSame($schema->getId(), $found->getId());
-	}
-
-	// =========================================================================
 	// find with different RBAC/multitenancy flags to exercise cache keys
 	// =========================================================================
 
@@ -1534,9 +1530,9 @@ class SchemaMapperIntegrationTest extends TestCase {
 		$schema = $this->createTestSchema();
 
 		// Call with RBAC=false, multitenancy=false
-		$found1 = $this->mapper->find($schema->getId(), [], null, false, false);
+		$found1 = $this->mapper->find($schema->getId(), _extend: [], _rbac: false, _multitenancy: false);
 		// Call with RBAC=true, multitenancy=false (different cache key)
-		$found2 = $this->mapper->find($schema->getId(), [], null, true, false);
+		$found2 = $this->mapper->find($schema->getId(), _extend: [], _rbac: true, _multitenancy: false);
 
 		$this->assertSame($found1->getId(), $found2->getId());
 	}
@@ -1547,7 +1543,7 @@ class SchemaMapperIntegrationTest extends TestCase {
 
 	public function testFindWithMultitenancyDisabled(): void {
 		$schema = $this->createTestSchema();
-		$found = $this->mapper->find($schema->getId(), [], null, false, false);
+		$found = $this->mapper->find($schema->getId(), _extend: [], _rbac: false, _multitenancy: false);
 		$this->assertSame($schema->getId(), $found->getId());
 	}
 
@@ -1566,7 +1562,6 @@ class SchemaMapperIntegrationTest extends TestCase {
 			['LOWER(title) LIKE :searchTitle'],
 			['searchTitle' => '%' . strtolower($uniqueTitle) . '%'],
 			[],
-			null,
 			false,
 			false
 		);

--- a/tests/Integration/RuntimeSchemaReloadTest.php
+++ b/tests/Integration/RuntimeSchemaReloadTest.php
@@ -151,6 +151,13 @@ class RuntimeSchemaReloadTest extends TestCase {
 	private array $createdObjectUuids = [];
 
 	/**
+	 * The session user this test found, restored in tearDown().
+	 *
+	 * @var \OCP\IUser|null
+	 */
+	private ?\OCP\IUser $previousSessionUser = null;
+
+	/**
 	 * Wire up real services or skip the suite if Nextcloud is not loaded.
 	 *
 	 * @return void
@@ -173,22 +180,66 @@ class RuntimeSchemaReloadTest extends TestCase {
 
 		$this->request = $this->createMock(IRequest::class);
 
-		$this->schemasController = new SchemasController(
-			'openregister',
-			$this->request,
-			\OC::$server->get(IAppConfig::class),
-			$this->schemaMapper,
-			$this->objectMapper,
-			\OC::$server->get(UploadService::class),
-			\OC::$server->get(AuditTrailMapper::class),
-			\OC::$server->get(OrganisationService::class),
-			$this->schemaCacheHandler,
-			\OC::$server->get(FacetCacheHandler::class),
-			\OC::$server->get(SchemaService::class),
-			\OC::$server->get(LoggerInterface::class)
-		);
+		// POST and PUT on /api/schemas are gated on manage permission, which is
+		// admin-only unless the schema declares a manage rule. With no session
+		// the controller answers 403 and the cache-invalidation contract under
+		// test is never reached, so the fixture logs in and tearDown puts the
+		// session back.
+		$userSession = \OC::$server->get(\OCP\IUserSession::class);
+		$this->previousSessionUser = $userSession->getUser();
+		$admin = \OC::$server->get(\OCP\IUserManager::class)->get('admin');
+		if ($admin !== null) {
+			$userSession->setUser($admin);
+		}
+
+		// Built from the container BY SIGNATURE, with the mock request spliced
+		// in. The old code listed twelve collaborators by hand; the controller
+		// takes seventeen now (registerMapper, the container itself,
+		// SchemaVersioningService and three optional services joined it), so a
+		// hand-written list goes red every time one is added, which is exactly
+		// what happened. Resolving it straight from the container is not an
+		// option either: that injects the real IRequest and these tests drive
+		// the controller through a stubbed one.
+		$this->schemasController = $this->buildSchemasController();
 
 	}//end setUp()
+
+	/**
+	 * Build SchemasController with every dependency the container knows.
+	 *
+	 * Each constructor parameter is resolved by its declared type, except the
+	 * app name and the request: those are the two the test owns. A dependency
+	 * added to the controller tomorrow is picked up here without editing.
+	 *
+	 * @return SchemasController The controller, wired to the stubbed request.
+	 */
+	private function buildSchemasController(): SchemasController {
+		$arguments = [];
+		foreach ((new \ReflectionClass(SchemasController::class))->getConstructor()->getParameters() as $parameter) {
+			$type = $parameter->getType();
+			$name = $type instanceof \ReflectionNamedType ? $type->getName() : '';
+
+			if ($parameter->getName() === 'appName') {
+				$arguments[] = 'openregister';
+				continue;
+			}
+
+			if ($name === IRequest::class) {
+				$arguments[] = $this->request;
+				continue;
+			}
+
+			try {
+				$arguments[] = \OC::$server->get($name);
+			} catch (\Throwable $e) {
+				// Optional collaborators are nullable with a default; an
+				// unresolvable one is left at its default rather than guessed at.
+				$arguments[] = $parameter->isDefaultValueAvailable() ? $parameter->getDefaultValue() : null;
+			}
+		}
+
+		return new SchemasController(...$arguments);
+	}//end buildSchemasController()
 
 	/**
 	 * Best-effort cleanup of every fixture created by a test method.
@@ -196,6 +247,10 @@ class RuntimeSchemaReloadTest extends TestCase {
 	 * @return void
 	 */
 	protected function tearDown(): void {
+		if (class_exists('\\OC') === true && isset(\OC::$server) === true) {
+			\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
+		}
+
 		$db = null;
 		if (class_exists('\\OC') === true && isset(\OC::$server) === true) {
 			try {
@@ -285,7 +340,13 @@ class RuntimeSchemaReloadTest extends TestCase {
 
 		// Same-worker GET MUST observe the new schema (cache invalidation proof).
 		$this->request = $this->createMock(IRequest::class);
-		$this->request->method('getParam')->willReturn(null);
+		// A real IRequest answers getParam() with the DEFAULT the caller passed,
+		// never null. show() asks for `_extend` with a default of [] and then
+		// in_array()s it, so a stub that returns null for everything makes the
+		// controller fail on a contract the framework does not break.
+		$this->request->method('getParam')->willReturnCallback(
+			static fn (string $key, mixed $default = null): mixed => $default
+		);
 		$reflection = new \ReflectionClass($this->schemasController);
 		$prop = $reflection->getProperty('request');
 		$prop->setAccessible(true);
@@ -374,10 +435,16 @@ class RuntimeSchemaReloadTest extends TestCase {
 
 		// 3. Persist an object so the DELETE-safety guard has something to trip on.
 		try {
+			// Named arguments: saveObject() takes ?array $extend second, so the
+			// positional form here handed the Register to $extend and the call
+			// died on a TypeError that the catch below reported as "object
+			// persistence not available", skipping a test that could run.
 			$created = $this->objectService->saveObject(
-				['name' => 'guard-fixture'],
-				$register,
-				$schema
+				object: ['name' => 'guard-fixture'],
+				register: $register,
+				schema: $schema,
+				_rbac: false,
+				_multitenancy: false
 			);
 			if (is_array($created) === true) {
 				$uuid = $created['uuid'] ?? null;

--- a/tests/Service/AggregationRunnerIntegrationTest.php
+++ b/tests/Service/AggregationRunnerIntegrationTest.php
@@ -45,6 +45,13 @@ class AggregationRunnerIntegrationTest extends TestCase {
 	private ?string $activeOrgUuid = null;
 
 	/**
+	 * The admin's active_organisation user value as this file found it.
+	 *
+	 * @var string
+	 */
+	private string $previousActiveOrganisation = '';
+
+	/**
 	 * @var int[]
 	 */
 	private array $createdSchemaIds = [];
@@ -96,6 +103,15 @@ class AggregationRunnerIntegrationTest extends TestCase {
 			$userSession->setUser($admin);
 		}
 
+		// 🔴 THE ACTIVE ORGANISATION IS A PERSISTENT USER SETTING, NOT SESSION
+		// STATE. setActiveOrganisation() writes it with setUserValue(), so a test
+		// that sets it changes the admin account for every later test, every
+		// later file and every later RUN. Two ServicesIntegrationTest tests read
+		// zero objects for rows they had just created because this file had
+		// pinned a tenant they were not stamped with. Capture it and put it back.
+		$config = \OC::$server->get(\OCP\IConfig::class);
+		$this->previousActiveOrganisation = $config->getUserValue('admin', 'openregister', 'active_organisation', '');
+
 		$orgService = \OC::$server->get(\OCA\OpenRegister\Service\OrganisationService::class);
 		$activeOrg = $orgService->getActiveOrganisation();
 		if ($activeOrg === null) {
@@ -110,6 +126,15 @@ class AggregationRunnerIntegrationTest extends TestCase {
 	}//end setUp()
 
 	protected function tearDown(): void {
+		// Restore the admin's active organisation exactly as it was found: an
+		// empty value means "no setting", which is deleted rather than stored.
+		$config = \OC::$server->get(\OCP\IConfig::class);
+		if ($this->previousActiveOrganisation === '') {
+			$config->deleteUserValue('admin', 'openregister', 'active_organisation');
+		} else {
+			$config->setUserValue('admin', 'openregister', 'active_organisation', $this->previousActiveOrganisation);
+		}
+
 		$db = \OC::$server->get(\OCP\IDBConnection::class);
 
 		foreach ($this->createdTables as $tableName) {

--- a/tests/Service/AggregationRunnerIntegrationTest.php
+++ b/tests/Service/AggregationRunnerIntegrationTest.php
@@ -469,6 +469,15 @@ class AggregationRunnerIntegrationTest extends TestCase {
 		);
 		$this->createdSchemaIds[] = $schema->getId();
 
+		// The register has to CARRY the schema. Naming a register is a boundary
+		// now: RegisterScopedSchemaResolver refuses to resolve a slug against a
+		// register that lists no schemas rather than guessing at a same-slug
+		// schema somewhere else, and its error says so ("carries no schemas at
+		// all"). This fixture predates that rule and seeded the two rows without
+		// ever linking them.
+		$register->setSchemas([$schema->getId()]);
+		$register = $this->registerMapper->update($register);
+
 		$this->mapper->ensureTableForRegisterSchema($register, $schema);
 		$this->createdTables[] = 'oc_' . $this->mapper->getTableNameForRegisterSchema($register, $schema);
 

--- a/tests/Service/GraphQLReferenceValidationIntegrationTest.php
+++ b/tests/Service/GraphQLReferenceValidationIntegrationTest.php
@@ -72,6 +72,20 @@ class GraphQLReferenceValidationIntegrationTest extends TestCase {
 	 */
 	private ?\OCP\IUser $previousSessionUser = null;
 
+	/**
+	 * App config, for the admin-bypass flag this file has to turn off.
+	 *
+	 * @var \OCP\IAppConfig
+	 */
+	private \OCP\IAppConfig $appConfig;
+
+	/**
+	 * The admin-bypass value as it was found, restored in tearDown().
+	 *
+	 * @var string
+	 */
+	private string $previousBypass = 'true';
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -87,6 +101,17 @@ class GraphQLReferenceValidationIntegrationTest extends TestCase {
 		if ($admin !== null) {
 			$userSession->setUser($admin);
 		}
+		// 🔴 AND THE CALLER MAY NOT BE WAVED THROUGH EITHER. Reference-existence
+		// validation has an operator escape hatch: an admin skips it entirely
+		// unless `reference_validation_admin_bypass` is off (SaveObject, default
+		// true), so with admin in the session the two rejection tests below saw
+		// their dangling references accepted. The flag goes off for this file and
+		// back to its previous value in tearDown, which is also what an operator
+		// who wants validation enforced for everybody does.
+		$this->appConfig = \OC::$server->get(\OCP\IAppConfig::class);
+		$this->previousBypass = $this->appConfig->getValueString('openregister', 'reference_validation_admin_bypass', 'true');
+		$this->appConfig->setValueString('openregister', 'reference_validation_admin_bypass', 'false');
+
 		$this->resolver = \OC::$server->get(GraphQLResolver::class);
 		$this->saveHandler = \OC::$server->get(SaveObject::class);
 		$this->objectService = \OC::$server->get(ObjectService::class);
@@ -141,8 +166,9 @@ class GraphQLReferenceValidationIntegrationTest extends TestCase {
 			}
 		}
 
-		// Put the session back the way it was found, so the next test file
-		// starts from the session state it expects.
+		// Put the bypass flag and the session back the way they were found, so
+		// the next test file starts from the state it expects.
+		$this->appConfig->setValueString('openregister', 'reference_validation_admin_bypass', $this->previousBypass);
 		\OC::$server->get(\OCP\IUserSession::class)->setUser($this->previousSessionUser);
 
 		parent::tearDown();

--- a/tests/Service/MailSmartPickerIntegrationTest.php
+++ b/tests/Service/MailSmartPickerIntegrationTest.php
@@ -227,22 +227,14 @@ class MailSmartPickerIntegrationTest extends TestCase {
 		$providerForAdmin = new ObjectReferenceProvider(
 			\OC::$server->get(\OCP\IURLGenerator::class),
 			\OC::$server->get(\OCP\L10N\IFactory::class)->get('openregister'),
-			\OC::$server->get(\OCA\OpenRegister\Service\ObjectService::class),
-			\OC::$server->get(\OCA\OpenRegister\Service\DeepLinkRegistryService::class),
-			\OC::$server->get(\OCA\OpenRegister\Db\SchemaMapper::class),
-			\OC::$server->get(\OCA\OpenRegister\Db\RegisterMapper::class),
-			\OC::$server->get(\Psr\Log\LoggerInterface::class),
+			\OC::$server->get(\OCA\OpenRegister\Service\Reference\ObjectPreviewFormatter::class),
 			'admin'
 		);
 
 		$providerForAnon = new ObjectReferenceProvider(
 			\OC::$server->get(\OCP\IURLGenerator::class),
 			\OC::$server->get(\OCP\L10N\IFactory::class)->get('openregister'),
-			\OC::$server->get(\OCA\OpenRegister\Service\ObjectService::class),
-			\OC::$server->get(\OCA\OpenRegister\Service\DeepLinkRegistryService::class),
-			\OC::$server->get(\OCA\OpenRegister\Db\SchemaMapper::class),
-			\OC::$server->get(\OCA\OpenRegister\Db\RegisterMapper::class),
-			\OC::$server->get(\Psr\Log\LoggerInterface::class),
+			\OC::$server->get(\OCA\OpenRegister\Service\Reference\ObjectPreviewFormatter::class),
 			null
 		);
 

--- a/tests/Service/McpToolScopingIntegrationTest.php
+++ b/tests/Service/McpToolScopingIntegrationTest.php
@@ -149,20 +149,21 @@ class McpToolScopingIntegrationTest extends TestCase {
 
 	}//end testObjectsToolReturnsErrorEnvelopeWhenBothMissing()
 
-	public function testExecuteObjectsThrowsInvalidArgumentExceptionDirectly(): void {
-		// The spec scenario specifies the exception type at the
-		// executeObjects() boundary (before callTool()'s try/catch). We
-		// call the private method via reflection to lock that contract.
-		$ref = new \ReflectionObject($this->tools);
-		$method = $ref->getMethod('executeObjects');
-		$method->setAccessible(true);
+	public function testObjectsProviderThrowsInvalidArgumentExceptionDirectly(): void {
+		// The spec scenario specifies the exception type at the boundary BELOW
+		// callTool()'s try/catch. That boundary moved: McpToolsService no longer
+		// carries a private executeObjects(); the objects tool is contributed by
+		// BuiltIn\ObjectsToolProvider and its invokeTool() raises the guard. The
+		// contract is the same and the provider is public, so no reflection is
+		// needed to lock it.
+		$provider = \OC::$server->get(\OCA\OpenRegister\Mcp\BuiltIn\ObjectsToolProvider::class);
 
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage('Both register and schema IDs are required for object operations');
 
-		$method->invoke($this->tools, ['action' => 'list']);
+		$provider->invokeTool(toolId: 'objects', arguments: ['action' => 'list']);
 
-	}//end testExecuteObjectsThrowsInvalidArgumentExceptionDirectly()
+	}//end testObjectsProviderThrowsInvalidArgumentExceptionDirectly()
 
 	public function testObjectsToolSetsRegisterAndSchemaOnObjectService(): void {
 		$this->tools->callTool(

--- a/tests/Service/ObjectHandlersIntegrationTest.php
+++ b/tests/Service/ObjectHandlersIntegrationTest.php
@@ -845,19 +845,13 @@ class ObjectHandlersIntegrationTest extends TestCase {
 		$this->assertCount(3, $result['_ids']);
 	}
 
-	/**
-	 * Test buildSearchQuery with published filter.
-	 */
-	public function testBuildSearchQueryPublishedFilter(): void {
-		$result = $this->searchQueryHandler->buildSearchQuery(
-			['_published' => 'true'],
-			null,
-			null
-		);
-
-		$this->assertArrayHasKey('_published', $result);
-		$this->assertTrue($result['_published']);
-	}
+	// testBuildSearchQueryPublishedFilter is gone: it asserted that
+	// buildSearchQuery() normalised `_published=true` into a boolean. The
+	// `_published` column was dropped from every magic table by
+	// Version1Date20260313130000 (2026-03-13) with the published metadata
+	// system, and no code in lib/ reads the filter any more, so the handler
+	// carries the key through as an ordinary unknown parameter. Visibility over
+	// time is an RBAC `match` rule with `$now` now.
 
 	/**
 	 * Test buildSearchQuery strips system params.
@@ -1005,12 +999,17 @@ class ObjectHandlersIntegrationTest extends TestCase {
 	 * Test hasGroupPermission action not in authorization.
 	 */
 	public function testHasGroupPermissionActionNotInAuth(): void {
+		// This asserted a GRANT. Once a schema opts into authorization, an action
+		// the block does not list is denied: the empty-block default is the only
+		// one that still grants, and admin and owner have already returned by
+		// then. Asserting the old default-open answer here would be asserting a
+		// hole, so the test follows the fail-closed rule.
 		$result = $this->permissionHandler->hasGroupPermission(
 			['create' => ['editors']],
 			'users',
 			'read'
 		);
-		$this->assertTrue($result);
+		$this->assertFalse($result, 'an action a non-empty authorization block does not list MUST be denied');
 	}
 
 	/**
@@ -1076,19 +1075,41 @@ class ObjectHandlersIntegrationTest extends TestCase {
 		);
 		$this->assertFalse($result);
 
-		// With matching organisation.
-		$result2 = $this->permissionHandler->hasGroupPermission(
-			$authorization,
-			'editors',
-			'read',
-			null,
-			null,
-			null,
-			null,
-			'org-uuid-123',
-			'org-uuid-123'
-		);
-		$this->assertTrue($result2);
+		// With the object in the CALLER's organisation. The active organisation
+		// used to be the ninth argument; hasGroupPermission() takes eight now and
+		// ConditionMatcher resolves `$organisation` itself through
+		// OrganisationService, so the test logs in and reads the value the
+		// matcher will see rather than passing one it no longer accepts.
+		$userSession = \OC::$server->get(\OCP\IUserSession::class);
+		$previous = $userSession->getUser();
+		$admin = \OC::$server->get(\OCP\IUserManager::class)->get('admin');
+		if ($admin === null) {
+			$this->markTestSkipped('no admin user on this instance');
+		}
+
+		$userSession->setUser($admin);
+		try {
+			$orgService = \OC::$server->get(\OCA\OpenRegister\Service\OrganisationService::class);
+			$activeOrg = $orgService->getActiveOrganisation();
+			if ($activeOrg === null) {
+				$this->markTestSkipped('no active organisation to match against');
+			}
+
+			$result2 = $this->permissionHandler->hasGroupPermission(
+				$authorization,
+				'editors',
+				'read',
+				null,
+				null,
+				null,
+				null,
+				$activeOrg->getUuid()
+			);
+		} finally {
+			$userSession->setUser($previous);
+		}
+
+		$this->assertTrue($result2, 'an object in the caller\'s own organisation MUST match $organisation');
 	}
 
 	/**

--- a/tests/Service/ObjectServiceIntegrationTest.php
+++ b/tests/Service/ObjectServiceIntegrationTest.php
@@ -21,6 +21,7 @@ use OCA\OpenRegister\Db\Register;
 use OCA\OpenRegister\Db\RegisterMapper;
 use OCA\OpenRegister\Db\Schema;
 use OCA\OpenRegister\Db\SchemaMapper;
+use OCA\OpenRegister\Exception\SchemaNotInRegisterException;
 use OCA\OpenRegister\Exception\ValidationException;
 use OCA\OpenRegister\Service\ObjectService;
 use PHPUnit\Framework\TestCase;
@@ -368,6 +369,13 @@ class ObjectServiceIntegrationTest extends TestCase {
 	 * @return void
 	 */
 	public function testSetSchemaWithSlug(): void {
+		// A slug is resolved INSIDE the current register since 5e7471bed
+		// (2026-08-22, "make {register} a hard boundary on every path that names
+		// one"). ObjectService is a singleton, so without naming the register
+		// this test inherited whichever one the previous test left behind and
+		// the slug resolved against the wrong boundary.
+		$this->service->setRegister($this->testRegister);
+
 		$result = $this->service->setSchema($this->testSchema->getSlug());
 
 		$this->assertInstanceOf(ObjectService::class, $result);
@@ -462,7 +470,13 @@ class ObjectServiceIntegrationTest extends TestCase {
 	 * @return void
 	 */
 	public function testSetSchemaWithNonexistentIdThrows(): void {
-		$this->expectException(ValidationException::class);
+		// Same boundary change: an id the current register does not carry is a
+		// SchemaNotInRegisterException (a DoesNotExistException), not the
+		// ValidationException the old unscoped lookup raised. The more specific
+		// exception is the point of 5e7471bed, so this follows it.
+		$this->service->setRegister($this->testRegister);
+
+		$this->expectException(SchemaNotInRegisterException::class);
 		$this->service->setSchema(999999999);
 	}
 
@@ -1294,62 +1308,14 @@ class ObjectServiceIntegrationTest extends TestCase {
 	}
 
 	// =========================================================================
-	// Publish / Depublish tests
-	// =========================================================================
-
-	/**
-	 * Test publishObjects bulk publish
-	 *
-	 * @return void
-	 */
-	public function testPublishObjectsBulk(): void {
-		$obj = $this->createTestObject(['name' => 'Publish Test']);
-
-		$this->service->setRegister($this->testRegister);
-		$this->service->setSchema($this->testSchema);
-
-		$result = $this->service->publishObjects(
-			[$obj->getUuid()],
-			true,
-			false,
-			false
-		);
-
-		$this->assertIsArray($result);
-	}
-
-	/**
-	 * Test depublishObjects bulk depublish
-	 *
-	 * @return void
-	 */
-	public function testDepublishObjectsBulk(): void {
-		$obj = $this->createTestObject(['name' => 'Depublish Test']);
-
-		$this->service->setRegister($this->testRegister);
-		$this->service->setSchema($this->testSchema);
-
-		// First publish
-		$this->service->publishObjects(
-			[$obj->getUuid()],
-			true,
-			false,
-			false
-		);
-
-		// Then depublish
-		$result = $this->service->depublishObjects(
-			[$obj->getUuid()],
-			true,
-			false,
-			false
-		);
-
-		$this->assertIsArray($result);
-	}
-
-	// =========================================================================
-	// Lock / Unlock tests
+	// Publish / Depublish: REMOVED, the feature is gone
+	//
+	// testPublishObjectsBulk and testDepublishObjectsBulk drove
+	// ObjectService::publishObjects() and depublishObjects(). Object-level
+	// published metadata was retired in 12927d356 (2026-03-13) in favour of RBAC
+	// `$now` rules, and those methods went with the routes. Nothing inherited
+	// them, so nothing inherits the tests. Visibility over time is now a
+	// `match` rule with `$now`, covered in RbacOperatorMatchingIntegrationTest.
 	// =========================================================================
 
 	/**
@@ -1470,24 +1436,6 @@ class ObjectServiceIntegrationTest extends TestCase {
 
 		// Objects deleted, remove from cleanup
 		$this->createdObjectUuids = [];
-	}
-
-	/**
-	 * Test publishObjectsBySchema
-	 *
-	 * @return void
-	 */
-	public function testPublishObjectsBySchema(): void {
-		$this->createTestObject(['name' => 'Schema Publish Test']);
-
-		$result = $this->service->publishObjectsBySchema(
-			$this->testSchema->getId(),
-			true
-		);
-
-		$this->assertIsArray($result);
-		$this->assertArrayHasKey('published_count', $result);
-		$this->assertArrayHasKey('schema_id', $result);
 	}
 
 	// =========================================================================

--- a/tests/Service/RbacScopeDiscoveryIntegrationTest.php
+++ b/tests/Service/RbacScopeDiscoveryIntegrationTest.php
@@ -89,6 +89,17 @@ class RbacScopeDiscoveryIntegrationTest extends TestCase {
 		$password = bin2hex(random_bytes(12)) . 'Aa9!';
 		$this->testUser = $this->userManager->createUser($this->testUserId, $password);
 
+		// Create the fixture AS ADMIN. SchemaMapper::insert() stamps the active
+		// session's organisation on the row, and ScopesController::index()
+		// resolves schemas with multitenancy ON, deliberately. Built under
+		// whatever user the previous file happened to leave behind, the schemas
+		// landed in another tenant and the admin-bypass test saw an empty scope
+		// list: the tuples existed, the caller could not see them.
+		$admin = $this->userManager->get('admin');
+		if ($admin !== null) {
+			$this->userSession->setUser($admin);
+		}
+
 		$this->createTestFixture();
 
 	}//end setUp()

--- a/tests/Service/RegisterI18nPhase2IntegrationTest.php
+++ b/tests/Service/RegisterI18nPhase2IntegrationTest.php
@@ -143,11 +143,19 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 		// Drive the middleware directly via a stub IRequest.
 		$request = $this->createMock(IRequest::class);
 		$request->method('getHeader')->with('Accept-Language')->willReturn('nl-NL, nl;q=0.9, en;q=0.8');
-		$request->method('getParam')->with('_translations')->willReturn(null);
+		// The middleware asks for several query parameters now (_lang before
+		// _translations), so the stub answers "not given" to all of them rather
+		// than pinning one name.
+		$request->method('getParam')->willReturn(null);
 
 		$svc = \OC::$server->get(LanguageService::class);
 		$svc->setFallbackUsed(false); // reset
-		$middleware = new LanguageMiddleware($request, $svc);
+		$middleware = new LanguageMiddleware(
+			request: $request,
+			languageService: $svc,
+			translationMapper: \OC::$server->get(\OCA\OpenRegister\Db\TranslationMapper::class),
+			logger: \OC::$server->get(\Psr\Log\LoggerInterface::class)
+		);
 		$middleware->beforeController(null, 'index');
 
 		// After-controller adds the Content-Language header.
@@ -166,7 +174,12 @@ class RegisterI18nPhase2IntegrationTest extends TestCase {
 
 		$svc = \OC::$server->get(LanguageService::class);
 		$svc->setFallbackUsed(true); // simulate a render that fell back
-		$middleware = new LanguageMiddleware($request, $svc);
+		$middleware = new LanguageMiddleware(
+			request: $request,
+			languageService: $svc,
+			translationMapper: \OC::$server->get(\OCA\OpenRegister\Db\TranslationMapper::class),
+			logger: \OC::$server->get(\Psr\Log\LoggerInterface::class)
+		);
 
 		$response = new JSONResponse(['ok' => true]);
 		$modified = $middleware->afterController(null, 'index', $response);

--- a/tests/Service/RelationHandlerCircuitBreakerTest.php
+++ b/tests/Service/RelationHandlerCircuitBreakerTest.php
@@ -50,6 +50,7 @@ class RelationHandlerCircuitBreakerTest extends TestCase {
 			performanceHandler: $this->createMock(PerformanceHandler::class),
 			rbacHandler: $this->createMock(MagicRbacHandler::class),
 			logger: $this->createMock(LoggerInterface::class),
+			registerMapper: $this->createMock(\OCA\OpenRegister\Db\RegisterMapper::class),
 		);
 	}//end setUp()
 

--- a/tests/Service/ServicesIntegrationTest.php
+++ b/tests/Service/ServicesIntegrationTest.php
@@ -1432,10 +1432,8 @@ class ServicesIntegrationTest extends TestCase {
 	 * @return void
 	 */
 	public function testAuthorizationServiceJwtNoToken(): void {
-		$service = \OC::$server->get(AuthorizationService::class);
-
 		$this->expectException(AuthenticationException::class);
-		$service->authorizeJwt('Bearer ');
+		$this->invokeAuthorize('authorizeJwt', ['Bearer ']);
 	}
 
 	/**
@@ -1444,10 +1442,8 @@ class ServicesIntegrationTest extends TestCase {
 	 * @return void
 	 */
 	public function testAuthorizationServiceOAuthNonBearer(): void {
-		$service = \OC::$server->get(AuthorizationService::class);
-
 		$this->expectException(AuthenticationException::class);
-		$service->authorizeOAuth('Basic dGVzdDp0ZXN0');
+		$this->invokeAuthorize('authorizeOAuth', ['Basic dGVzdDp0ZXN0']);
 	}
 
 	/**
@@ -1456,10 +1452,30 @@ class ServicesIntegrationTest extends TestCase {
 	 * @return void
 	 */
 	public function testAuthorizationServiceApiKeyInvalid(): void {
-		$service = \OC::$server->get(AuthorizationService::class);
-
 		$this->expectException(AuthenticationException::class);
-		$service->authorizeApiKey('invalid-key', ['valid-key' => 'admin']);
+		$this->invokeAuthorize('authorizeApiKey', ['invalid-key', ['valid-key' => 'admin']]);
+	}
+
+	/**
+	 * Call one of AuthorizationService's credential checks.
+	 *
+	 * authorizeJwt(), authorizeOAuth() and authorizeApiKey() were public when
+	 * these tests were written and became protected in 3fd738a0b (2026-05-28),
+	 * the pass that answered the orphan-auth gate. Nothing in lib/ calls them
+	 * directly, so there is no public route to drive them through, and the
+	 * behaviour they hold is worth keeping pinned: a malformed or absent
+	 * credential MUST raise AuthenticationException rather than fall through.
+	 *
+	 * @param string $method The check to call.
+	 * @param array  $args   Its arguments.
+	 *
+	 * @return void
+	 */
+	private function invokeAuthorize(string $method, array $args): void {
+		$service = \OC::$server->get(AuthorizationService::class);
+		$reflected = new \ReflectionMethod($service, $method);
+		$reflected->setAccessible(true);
+		$reflected->invoke($service, ...$args);
 	}
 
 	// -------------------------------------------------------------------------
@@ -1564,12 +1580,22 @@ class ServicesIntegrationTest extends TestCase {
 		$result = $service->listTools();
 
 		$this->assertArrayHasKey('tools', $result);
-		$this->assertCount(3, $result['tools']);
 
+		// The count used to be pinned at three. Tools are contributed by
+		// providers and the fleet keeps adding them (seven on this instance), so
+		// a hard count is a number someone has to bump rather than a fact worth
+		// protecting. What matters is that the three canonical tools are still
+		// advertised, and that every entry is shaped the way a client expects.
 		$toolNames = array_column($result['tools'], 'name');
 		$this->assertContains('registers', $toolNames);
 		$this->assertContains('schemas', $toolNames);
 		$this->assertContains('objects', $toolNames);
+
+		foreach ($result['tools'] as $tool) {
+			$this->assertArrayHasKey('name', $tool);
+			$this->assertArrayHasKey('description', $tool);
+			$this->assertArrayHasKey('inputSchema', $tool);
+		}
 	}
 
 	/**
@@ -1635,10 +1661,14 @@ class ServicesIntegrationTest extends TestCase {
 	 * @return void
 	 */
 	public function testMcpToolsServiceUnknownTool(): void {
+		// The service throws for a tool nobody owns; McpServerController catches
+		// InvalidArgumentException and answers a JSON-RPC error. The old
+		// expectation of an isError envelope predates that mapping.
 		$service = \OC::$server->get(McpToolsService::class);
-		$result = $service->callTool('nonexistent', ['action' => 'list']);
 
-		$this->assertTrue($result['isError']);
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Unknown tool: nonexistent');
+		$service->callTool('nonexistent', ['action' => 'list']);
 	}
 
 	/**

--- a/tests/Service/ServicesIntegrationTest.php
+++ b/tests/Service/ServicesIntegrationTest.php
@@ -281,6 +281,21 @@ class ServicesIntegrationTest extends TestCase {
 	 *
 	 * @return ObjectEntity
 	 */
+	/**
+	 * The UUID of the caller's active organisation, or null when there is none.
+	 *
+	 * @return string|null The organisation UUID to stamp on fixture rows.
+	 */
+	private function activeOrganisationUuid(): ?string {
+		$orgService = \OC::$server->get(\OCA\OpenRegister\Service\OrganisationService::class);
+
+		try {
+			return $orgService->getActiveOrganisation()?->getUuid();
+		} catch (\Throwable $e) {
+			return null;
+		}
+	}//end activeOrganisationUuid()
+
 	private function createTestObject(array $data = []): ObjectEntity {
 		$uuid = Uuid::v4()->toRfc4122();
 		$objectData = array_merge([
@@ -295,7 +310,14 @@ class ServicesIntegrationTest extends TestCase {
 		$object->setSchema($this->testSchema->getId());
 		$object->setObject($objectData);
 		$object->setOwner('admin');
-		$object->setOrganisation('default');
+		// The tenant column holds an organisation UUID. This stamped the literal
+		// string 'default', which matches no organisation, so every read that
+		// applies the tenant filter skipped these rows: two tests counted zero
+		// objects they had just created, but only once the account had an active
+		// organisation, which OrganisationService assigns on first read. The
+		// production SaveObject path stamps the caller's organisation; the
+		// fixture does the same.
+		$object->setOrganisation($this->activeOrganisationUuid());
 
 		$inserted = $this->objectMapper->insert($object);
 		$this->createdObjectUuids[] = $uuid;

--- a/tests/Service/SettingsHandlersIntegrationTest.php
+++ b/tests/Service/SettingsHandlersIntegrationTest.php
@@ -259,18 +259,23 @@ class SettingsHandlersIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Test clearCache with type 'all' triggers TypeError due to int+string bug
+	 * Clearing every cache counts what it can and does not throw.
 	 *
-	 * The distributed cache returns 'all' (string) for 'cleared' which causes
-	 * a TypeError when calculating totalCleared. This tests the known bug path.
+	 * This test used to PIN A BUG: the distributed cache reports 'all' rather
+	 * than a number for `cleared`, and summing that into an int threw a
+	 * TypeError, which the test asserted. The sum guards with is_int() now, so
+	 * the test asserts the repair instead. A test that fails when a bug is fixed
+	 * is worse than no test.
 	 *
 	 * @return void
 	 */
-	public function testClearCacheAllTriggersTypeError(): void {
-		// Known bug: distributed cache returns 'all' string for cleared count,
-		// causing TypeError when summing totalCleared.
-		$this->expectException(\TypeError::class);
-		$this->cacheHandler->clearCache('all');
+	public function testClearCacheAllCountsWhatItCanAndDoesNotThrow(): void {
+		$result = $this->cacheHandler->clearCache('all');
+
+		$this->assertSame('all', $result['type']);
+		$this->assertIsInt($result['totalCleared']);
+		$this->assertArrayHasKey('distributed', $result['results']);
+		$this->assertSame([], $result['errors']);
 	}
 
 	/**
@@ -300,17 +305,19 @@ class SettingsHandlersIntegrationTest extends TestCase {
 	}
 
 	/**
-	 * Test clearCache with type 'distributed' triggers TypeError due to int+string bug
+	 * The distributed cache's non-numeric count is tolerated, not fatal.
 	 *
-	 * The distributed cache returns 'all' (string) for 'cleared' which causes
-	 * a TypeError when calculating totalCleared.
+	 * Same repair as above, from the other door: clearing only the distributed
+	 * cache is the case that produced the 'all' string in the first place.
 	 *
 	 * @return void
 	 */
-	public function testClearCacheDistributedTriggersTypeError(): void {
-		// Known bug: distributed cache returns 'all' string for cleared count.
-		$this->expectException(\TypeError::class);
-		$this->cacheHandler->clearCache('distributed');
+	public function testClearCacheDistributedToleratesANonNumericCount(): void {
+		$result = $this->cacheHandler->clearCache('distributed');
+
+		$this->assertSame('distributed', $result['type']);
+		$this->assertIsInt($result['totalCleared']);
+		$this->assertArrayHasKey('distributed', $result['results']);
 	}
 
 	/**

--- a/tests/Service/TextExtractionServiceIntegrationTest.php
+++ b/tests/Service/TextExtractionServiceIntegrationTest.php
@@ -1178,10 +1178,27 @@ class TextExtractionServiceIntegrationTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function testDetectEntitiesUnknownMethod(): void {
-		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('Unknown detection method');
-		$this->invokePrivate($this->entityHandler, 'detectEntities', ['text', 'nonexistent_method', null, 0.5]);
+	/**
+	 * An unrecognised detection method resolves, it does not throw.
+	 *
+	 * This asserted an "Unknown detection method" exception. 35d3d46de
+	 * (2026-06-18, "make OpenAnonymiser anonymisation work end-to-end") put
+	 * resolveMethod() in front of the match: a name that is not one of
+	 * BackendState::METHODS becomes the effective backend method, and falls back
+	 * to regex with a warning when the backend cannot be read. The `default =>
+	 * throw` arm is unreachable for a caller-supplied name now, which is the
+	 * point: a typo in a request parameter must not 500.
+	 *
+	 * @return void
+	 */
+	public function testDetectEntitiesResolvesAnUnknownMethodInsteadOfThrowing(): void {
+		$entities = $this->invokePrivate(
+			$this->entityHandler,
+			'detectEntities',
+			['Contact ruben@example.com about this.', 'nonexistent_method', null, 0.5]
+		);
+
+		$this->assertIsArray($entities);
 	}
 
 	// =======================================================================

--- a/tests/Service/TextExtractionWordExtractionTest.php
+++ b/tests/Service/TextExtractionWordExtractionTest.php
@@ -38,6 +38,13 @@ class TextExtractionWordExtractionTest extends TestCase {
 	private TextExtractionService $service;
 
 	/**
+	 * The handler that owns the Word reader selection and the element walk.
+	 *
+	 * @var \OCA\OpenRegister\Service\TextExtraction\WordExtractor
+	 */
+	private \OCA\OpenRegister\Service\TextExtraction\WordExtractor $wordExtractor;
+
+	/**
 	 * Temp fixture paths to clean up.
 	 *
 	 * @var string[]
@@ -50,6 +57,10 @@ class TextExtractionWordExtractionTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->service = \OC::$server->get(TextExtractionService::class);
+		// resolveWordReader() and walkWordElements() moved to WordExtractor with
+		// the extract-god-class-services split, behaviour unchanged.
+		// TextExtractionService::extractWord() is now a one-line delegation to it.
+		$this->wordExtractor = \OC::$server->get(\OCA\OpenRegister\Service\TextExtraction\WordExtractor::class);
 	}
 
 	/**
@@ -159,14 +170,14 @@ class TextExtractionWordExtractionTest extends TestCase {
 		$docx = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 		$odt = 'application/vnd.oasis.opendocument.text';
 
-		$this->assertSame('Word2007', $this->invokePrivate($this->service, 'resolveWordReader', [$docx, 'a.docx']));
-		$this->assertSame('MsDoc', $this->invokePrivate($this->service, 'resolveWordReader', ['application/msword', 'a.doc']));
-		$this->assertSame('ODText', $this->invokePrivate($this->service, 'resolveWordReader', [$odt, 'a.odt']));
+		$this->assertSame('Word2007', $this->invokePrivate($this->wordExtractor, 'resolveWordReader', [$docx, 'a.docx']));
+		$this->assertSame('MsDoc', $this->invokePrivate($this->wordExtractor, 'resolveWordReader', ['application/msword', 'a.doc']));
+		$this->assertSame('ODText', $this->invokePrivate($this->wordExtractor, 'resolveWordReader', [$odt, 'a.odt']));
 		// Generic MIME → fall back to extension.
-		$this->assertSame('MsDoc', $this->invokePrivate($this->service, 'resolveWordReader', ['application/octet-stream', 'legacy.doc']));
-		$this->assertSame('ODText', $this->invokePrivate($this->service, 'resolveWordReader', ['application/octet-stream', 'open.odt']));
+		$this->assertSame('MsDoc', $this->invokePrivate($this->wordExtractor, 'resolveWordReader', ['application/octet-stream', 'legacy.doc']));
+		$this->assertSame('ODText', $this->invokePrivate($this->wordExtractor, 'resolveWordReader', ['application/octet-stream', 'open.odt']));
 		// Unknown MIME and extension → safe default.
-		$this->assertSame('Word2007', $this->invokePrivate($this->service, 'resolveWordReader', ['application/octet-stream', 'mystery.bin']));
+		$this->assertSame('Word2007', $this->invokePrivate($this->wordExtractor, 'resolveWordReader', ['application/octet-stream', 'mystery.bin']));
 	}
 
 	/**
@@ -287,7 +298,7 @@ class TextExtractionWordExtractionTest extends TestCase {
 			};
 		}
 
-		$text = $this->invokePrivate($this->service, 'walkWordElements', [[$node], 0]);
+		$text = $this->invokePrivate($this->wordExtractor, 'walkWordElements', [[$node], 0]);
 
 		$this->assertIsString($text);
 		$this->assertStringNotContainsString('DEEP_LEAF_TEXT', $text, 'leaf beyond MAX_WORD_DEPTH must not be reached');
@@ -328,7 +339,7 @@ class TextExtractionWordExtractionTest extends TestCase {
 			}
 		};
 
-		$text = $this->invokePrivate($this->service, 'walkWordElements', [[$container], 0]);
+		$text = $this->invokePrivate($this->wordExtractor, 'walkWordElements', [[$container], 0]);
 		$this->assertStringContainsString('SHALLOW_LEAF_TEXT', $text);
 	}
 
@@ -340,7 +351,9 @@ class TextExtractionWordExtractionTest extends TestCase {
 	 * @return void
 	 */
 	public function testParseFailureLogsNoDocumentContent(): void {
-		$src = (string)file_get_contents(__DIR__ . '/../../lib/Service/TextExtractionService.php');
+		// The failure-path log moved with the code: extractWord() delegates to
+		// WordExtractor::extract(), which is where the catch block lives now.
+		$src = (string)file_get_contents(__DIR__ . '/../../lib/Service/TextExtraction/WordExtractor.php');
 
 		// Isolate the failure-path log call inside extractWord().
 		$start = strpos($src, 'Word extraction failed; returning null');


### PR DESCRIPTION
## What changed

Wave 5 of the dark-suites programme: the per-file repairs left in the Database, Integration and Service suites once waves 1 to 4 had landed. Those suites never run in CI (`defaultTestSuite="Unit Tests"`), so most of this is test rot, and three failures were real defects.

### Product fixes

- **Audit retention on PostgreSQL.** `AuditTrailMapper::setExpiryDate()` built `DATE_ADD(created, INTERVAL n SECOND)`, which only MySQL and MariaDB accept, so it would throw on every PostgreSQL install once called. It now spells the interval per platform, as `SearchTrailMapper` already does. The integration test used to skip on PostgreSQL and now runs on both.
- **Dashboard recalculate sizes did nothing.** `DashboardService::recalculateSizes()` passed register and schema ids to `MagicMapper::findAll()` as filters. A magic table is one table per register and schema pair, so `findAll()` answered an empty array and the method reported success after processing zero objects on every install. It now walks the register and schema pairs, narrowed by whichever id the caller named, and counts an unresolvable pair as one failure instead of aborting.
- **Object cache clear reported 0.** `CacheSettingsHandler::clearObjectCache()` read an `entries` key that `getStats()` never returns. #3700 made it read `cache_size`; this branch counts all three in-memory caches that `clearCache()` empties (`cache_size`, `query_cache_size`, `name_cache_size`). The merge conflict with #3700 was resolved in favour of the three-cache count.

### Test repairs

Schema and Register mapper tests drop the retired `published` argument. The RBAC tests assert the fail-closed rule on the emitter a CLI process can reach. The organisation offset test seeds its own data instead of skipping on an empty instance. Five service fixtures follow their production signatures. The publish tests in ObjectService are retired. The Word extraction tests follow the reader into its own handler. The MCP and schema tests follow the objects guard to its provider. The GraphQL reference tests turn the admin bypass off. The fixtures stamp the real organisation, and the scope test builds its fixture as the admin it acts as. Each commit message carries its own before and after count.

Twelve unit tests still pinned the two old shapes above (`findAll()` with filters, and an `entries` key), so they now follow the pair walk and the three cache sizes. The recalculate tests assert which pair tables are read for each filter; removing the register filter reddens that test on its assertion.

## What I verified locally

Merged `origin/development` at 7916a4916 (which includes #3700) first.

- Diff check (`diff-check.py` from hydra `development`, gates from this clone's `vendor/conduction/hydra-gates`): gates PASS, `php -l` PASS, phpstan PASS. The first run found 12 failing unit tests in `DashboardServiceTest` and `CacheSettingsHandlerTest`; after the repair commit, phpunit on the touched classes PASS (61 and 40 tests).
- `COMPOSER_PROCESS_TIMEOUT=0 composer check:strict` on 47febef9d: lint, migration-version, phpcs, phpmd, psalm (no errors) and phpstan (no errors) pass. `test:all` ran 20,160 tests, all OK with 24 skipped, and exits 1 only on the PHPUnit runner warning "No code coverage driver available" on this machine.
- Suite counts, measured by the wave 5 lane in `conduction/nextcloud:34.0.0-apache-soap` with PostgreSQL 16, before and after this branch:

| Suite | Before | After |
|---|---|---|
| Database | 565 tests, 39 errors, 6 failures | 563 tests, all passing |
| Integration | 10 tests, 4 errors, 2 skipped | 10 tests, 0 errors, 2 skipped |
| Service | 1,416 tests, 194 errors, 17 failures | 1,412 tests, 160 errors, 1 failure |

All 160 Service errors in that after-run are in `ControllersIntegrationTest` (101) and `ObjectsControllerIntegrationTest` (59), which are exactly the tests #3700 repaired. The one failure was `RbacScopeDiscoveryIntegrationTest`, which the last commit on this branch addresses. I did not re-run the three suites against the merged result: this machine has no isolated Nextcloud up and its C: drive is at 100%.

## Inherited findings

The diff check's phpcs reads `tests/` with `phpcs.xml`, whose own scope is `lib` only, and reports about 3,000 findings on untouched lines of these test files, plus about 100 on touched lines. They are the named-arguments and `\OC::$server` patterns those files already use throughout, and `composer phpcs` does not check them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)